### PR TITLE
format customer date of birth as date instead of datetime

### DIFF
--- a/src/Model/Customer/CustomerDraft.php
+++ b/src/Model/Customer/CustomerDraft.php
@@ -77,7 +77,7 @@ class CustomerDraft extends JsonObject
             'externalId' => [static::TYPE => 'string'],
             'dateOfBirth' => [
                 static::TYPE => '\DateTime',
-                static::DECORATOR => '\Commercetools\Core\Model\Common\DateTimeDecorator'
+                static::DECORATOR => '\Commercetools\Core\Model\Common\DateDecorator'
             ],
             'companyName' => [static::TYPE => 'string'],
             'vatId' => [static::TYPE => 'string'],


### PR DESCRIPTION
The customer draft serializes the customer date of birth as an ISO 8601 string. The APi expects Y-m-d.