### PR TITLE
Fix incorrect params

### DIFF
--- a/src/Request/Products/ProductsSuggestRequest.php
+++ b/src/Request/Products/ProductsSuggestRequest.php
@@ -146,9 +146,7 @@ class ProductsSuggestRequest extends AbstractProjectionRequest
             $params[] = 'searchKeywords.' . $lang . '=' . urlencode($keyword);
         }
 
-        $params = array_merge($params, array_keys($this->params));
-        sort($params);
-        $params = implode('&', $params);
+        $params = parent::convertToString(array_merge($this->params, $params));
 
         return (!empty($params) ? '?' . $params : '');
     }

--- a/src/Request/Products/ProductsSuggestRequest.php
+++ b/src/Request/Products/ProductsSuggestRequest.php
@@ -79,13 +79,19 @@ class ProductsSuggestRequest extends AbstractProjectionRequest
     }
 
     /**
-     * @param bool $fuzzy
+     * @param bool|int $level
      * @return $this
      */
-    public function fuzzy($fuzzy)
+    public function fuzzy($level)
     {
-        if (!is_null($fuzzy)) {
-            $this->addParamObject(new Parameter('fuzzy', (bool)$fuzzy));
+        if (!is_bool($level)) {
+            $level = min(2, max(0, (int)$level));
+        }
+        $fuzzy = (bool)$level;
+        $this->addParamObject(new Parameter('fuzzy', $fuzzy));
+
+        if (!is_bool($level) && $fuzzy) {
+            $this->addParamObject(new Parameter('fuzzyLevel', $level));
         }
 
         return $this;
@@ -142,12 +148,12 @@ class ProductsSuggestRequest extends AbstractProjectionRequest
     public function getParamString()
     {
         $params = [];
-        foreach ($this->searchKeywords->toArray() as $lang => $keyword) {
-            $params[] = 'searchKeywords.' . $lang . '=' . urlencode($keyword);
+        foreach ($this->getSearchKeywords()->toArray() as $lang => $keyword) {
+            $param = new Parameter('searchKeywords.' . $lang, $keyword);
+            $params[$param->getId()] = $param;
         }
 
-        $params = parent::convertToString(array_merge($this->params, $params));
-
+        $params = $this->convertToString(array_merge($this->params, $params));
         return (!empty($params) ? '?' . $params : '');
     }
 

--- a/tests/unit/Request/Products/ProductsSuggestRequestTest.php
+++ b/tests/unit/Request/Products/ProductsSuggestRequestTest.php
@@ -46,6 +46,49 @@ class ProductsSuggestRequestTest extends RequestTestCase
         $this->assertEmpty($result->toArray());
     }
 
+    public function fuzzyProvider()
+    {
+        return [
+            [true, 'fuzzy=true'],
+            [false, 'fuzzy=false'],
+            [-1, 'fuzzy=false'],
+            [ 0, 'fuzzy=false'],
+            [ 1, 'fuzzy=true&fuzzyLevel=1'],
+            [ 2, 'fuzzy=true&fuzzyLevel=2'],
+            [ 3, 'fuzzy=true&fuzzyLevel=2'],
+            ['1', 'fuzzy=true&fuzzyLevel=1'],
+        ];
+    }
+
+    /**
+     * @dataProvider  fuzzyProvider
+     */
+    public function testFuzzyLevel($level, $expected)
+    {
+        /**
+         * @var ProductsSuggestRequest $request
+         */
+        $request = $this->getRequest(static::PRODUCT_SUGGEST_REQUEST);
+        $request->fuzzy($level);
+        $httpRequest = $request->httpRequest();
+
+        $this->assertStringStartsWith('product-projections/suggest', (string)$httpRequest->getUri());
+        $this->assertContains($expected, (string)$httpRequest->getUri());
+    }
+
+    public function testFuzzyKeyword()
+    {
+        $request = $this->getRequest(static::PRODUCT_SUGGEST_REQUEST);
+        /**
+         * @var ProductsSuggestRequest $request
+         */
+        $request->fuzzy(true)->addKeyword('en', 'test');
+        $httpRequest = $request->httpRequest();
+
+        $this->assertStringStartsWith('product-projections/suggest', (string)$httpRequest->getUri());
+        $this->assertContains('fuzzy=true&searchKeywords.en=test', (string)$httpRequest->getUri());
+    }
+    
     public function testAddKeyword()
     {
         $request = ProductsSuggestRequest::of();


### PR DESCRIPTION
Fix incorrect parsing of params at products suggest requests. Currently, all params added by `addParam` oder `addParamObject` will only contain the key.

Example ...
```
$search = 'foobar';
$request = ProductsSuggestRequest::ofKeywords(LocalizedString::ofLangAndText('de', $search));
$request->fuzzy(true);
```
... will output: `?fuzzy&searchKeywords.de=memory`

With this fix:
`?fuzzy=true&searchKeywords.de=memory`