### PR TITLE
Never ever recommend to install dev-master with composer

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ curl -sS https://getcomposer.org/installer | php
 Next, run the Composer command to install the latest version of the SDK:
 
 ```bash
-composer require commercetools/php-sdk dev-master
+composer require commercetools/php-sdk
 ```
 
 The SDK supports Guzzle6 as well as Guzzle5 as HTTP client. For Guzzle6:


### PR DESCRIPTION
This is a very bad practice and leads to unstable installation and bothersome support request.

Without any version constraint composer is able to figure out the best and latest version constraint for the user.

Any user who needs the dev version should know how to install that with composer :smirk: 