### PR TITLE
Fix offsetExists for not preset values

### DIFF
--- a/src/Core/Model/Common/Context.php
+++ b/src/Core/Model/Common/Context.php
@@ -204,7 +204,7 @@ class Context implements \ArrayAccess
      */
     public function offsetExists($offset)
     {
-        return isset($this->$offset);
+        return property_exists($this, $offset);
     }
 
     /**


### PR DESCRIPTION
Using `isset` will not work if the values are not set on construct (because `isset` will return false for null values). For example if the intl extension is not installed

```php
if (extension_loaded('intl')) {
    $this->locale = \Locale::getDefault();
}
``` 

`$this->locale` will be not set and remains to be `null`. So the following will not set the locale (as expected):

```
$context = new Context();
$context['locale'] = 'en';
```