### PR TITLE
Subscription integration test refactor not sure

### DIFF
--- a/tests/integration/CartDiscount/CartDiscountCreateRequestTest.php
+++ b/tests/integration/CartDiscount/CartDiscountCreateRequestTest.php
@@ -3,7 +3,6 @@
  * @author @jenschude <jens.schulze@commercetools.de>
  */
 
-
 namespace Commercetools\Core\IntegrationTests\CartDiscount;
 
 use Commercetools\Core\Builder\Request\RequestBuilder;

--- a/tests/integration/CartDiscount/CartDiscountCreateRequestTest.php
+++ b/tests/integration/CartDiscount/CartDiscountCreateRequestTest.php
@@ -6,6 +6,7 @@
 namespace Commercetools\Core\IntegrationTests\CartDiscount;
 
 use Commercetools\Core\Builder\Request\RequestBuilder;
+use Commercetools\Core\Fixtures\FixtureException;
 use Commercetools\Core\IntegrationTests\ApiTestCase;
 use Commercetools\Core\Model\CartDiscount\CartDiscount;
 use Commercetools\Core\Model\CartDiscount\CartDiscountDraft;
@@ -50,6 +51,32 @@ class CartDiscountCreateRequestTest extends ApiTestCase
                     $result->current()->getRequiresDiscountCode()
                 );
                 $this->assertSame($cartDiscount->getKey(), $result->current()->getKey());
+            }
+        );
+    }
+
+    public function testDeleteByKey()
+    {
+        $client = $this->getApiClient();
+
+        $this->expectException(FixtureException::class);
+        $this->expectExceptionCode(404);
+
+        CartDiscountFixture::withDraftCartDiscount(
+            $client,
+            function (CartDiscountDraft $draft) {
+                return $draft->setName(LocalizedString::ofLangAndText('en', 'delete-by-key'))
+                    ->setKey('test-' . $this->getTestRun() . '-delete');
+            },
+            function (CartDiscount $cartDiscount) use ($client) {
+                $request = RequestBuilder::of()->cartDiscounts()->deleteByKey($cartDiscount);
+                $response = $this->execute($client, $request);
+                $result = $request->mapFromResponse($response);
+                $this->assertInstanceOf(CartDiscount::class, $result);
+
+                $request = RequestBuilder::of()->cartDiscounts()->getByKey($result->getKey());
+                $response = $this->execute($client, $request);
+                $request->mapFromResponse($response);
             }
         );
     }

--- a/tests/integration/CartDiscount/CartDiscountQueryRequestTest.php
+++ b/tests/integration/CartDiscount/CartDiscountQueryRequestTest.php
@@ -3,7 +3,6 @@
  * @author @jenschude <jens.schulze@commercetools.de>
  */
 
-
 namespace Commercetools\Core\IntegrationTests\CartDiscount;
 
 use Commercetools\Core\Builder\Request\RequestBuilder;
@@ -43,7 +42,7 @@ class CartDiscountQueryRequestTest extends ApiTestCase
                 $result = $request->mapFromResponse($response);
 
                 $this->assertInstanceOf(CartDiscount::class, $result);
-                $this->assertSame($cartDiscount->getId(), $result->getId());
+                $this->assertSame($cartDiscount->getKey(), $result->getKey());
             }
         );
     }

--- a/tests/integration/CartDiscount/CartDiscountUpdateRequestTest.php
+++ b/tests/integration/CartDiscount/CartDiscountUpdateRequestTest.php
@@ -411,30 +411,4 @@ class CartDiscountUpdateRequestTest extends ApiTestCase
             }
         );
     }
-
-    public function testDeleteByKey()
-    {
-        $client = $this->getApiClient();
-
-        $this->expectException(FixtureException::class);
-        $this->expectExceptionCode(404);
-
-        CartDiscountFixture::withDraftCartDiscount(
-            $client,
-            function (CartDiscountDraft $draft) {
-                return $draft->setName(LocalizedString::ofLangAndText('en', 'delete-by-key'))
-                    ->setKey('test-' . $this->getTestRun() . '-delete');
-            },
-            function (CartDiscount $cartDiscount) use ($client) {
-                $request = RequestBuilder::of()->cartDiscounts()->deleteByKey($cartDiscount);
-                $response = $this->execute($client, $request);
-                $result = $request->mapFromResponse($response);
-                $this->assertInstanceOf(CartDiscount::class, $result);
-
-                $request = RequestBuilder::of()->cartDiscounts()->getByKey($result->getKey());
-                $response = $this->execute($client, $request);
-                $request->mapFromResponse($response);
-            }
-        );
-    }
 }

--- a/tests/integration/CartDiscount/CartDiscountUpdateRequestTest.php
+++ b/tests/integration/CartDiscount/CartDiscountUpdateRequestTest.php
@@ -170,10 +170,10 @@ class CartDiscountUpdateRequestTest extends ApiTestCase
         CartDiscountFixture::withUpdateableDraftCartDiscount(
             $client,
             function (CartDiscountDraft $draft) {
-                return $draft->setName(LocalizedString::ofLangAndText('en', 'set-description'));
+                return $draft->setDescription(LocalizedString::ofLangAndText('en', 'set-description'));
             },
             function (CartDiscount $cartDiscount) use ($client) {
-                $description = LocalizedString::ofLangAndText('en', $this->getTestRun() . '-new-description');
+                $description = LocalizedString::ofLangAndText('en', 'new-description');
                 $request = RequestBuilder::of()->cartDiscounts()->update($cartDiscount)
                     ->addAction(CartDiscountSetDescriptionAction::of()->setDescription($description));
                 $response = $this->execute($client, $request);

--- a/tests/integration/State/StateFixture.php
+++ b/tests/integration/State/StateFixture.php
@@ -1,0 +1,141 @@
+<?php
+
+namespace Commercetools\Core\IntegrationTests\State;
+
+use Commercetools\Core\Client\ApiClient;
+use Commercetools\Core\Helper\Uuid;
+use Commercetools\Core\IntegrationTests\ResourceFixture;
+use Commercetools\Core\IntegrationTests\TestHelper;
+use Commercetools\Core\Model\State\AbsoluteStateValue;
+use Commercetools\Core\Model\State\State;
+use Commercetools\Core\Model\State\StateDraft;
+use Commercetools\Core\Model\State\StateTarget;
+use Commercetools\Core\Model\Common\LocalizedString;
+use Commercetools\Core\Model\Common\Money;
+use Commercetools\Core\Model\Common\MoneyCollection;
+use Commercetools\Core\Request\States\StateCreateRequest;
+use Commercetools\Core\Request\States\StateDeleteRequest;
+
+class StateFixture extends ResourceFixture
+{
+    const CREATE_REQUEST_TYPE = StateCreateRequest::class;
+    const DELETE_REQUEST_TYPE = StateDeleteRequest::class;
+
+    final public static function uniqueStateString()
+    {
+        return 'test-' . Uuid::uuidv4();
+    }
+
+    final public static function defaultStateDraftFunction()
+    {
+        $uniqueStateString = self::uniqueStateString();
+        $draft = StateDraft::ofKey('test-' . $uniqueStateString . '-key');
+
+        return $draft;
+    }
+
+    final public static function defaultStateDraftBuilderFunction(StateDraft $draft)
+    {
+        return $draft;
+    }
+
+    final public static function defaultStateCreateFunction(ApiClient $client, StateDraft $draft)
+    {
+        return parent::defaultCreateFunction($client, self::CREATE_REQUEST_TYPE, $draft);
+    }
+
+    final public static function defaultStateDeleteFunction(ApiClient $client, State $resource)
+    {
+        return parent::defaultDeleteFunction($client, self::DELETE_REQUEST_TYPE, $resource);
+    }
+
+    final public static function withUpdateableDraftState(
+        ApiClient $client,
+        callable $draftBuilderFunction,
+        callable $assertFunction,
+        callable $createFunction = null,
+        callable $deleteFunction = null,
+        callable $draftFunction = null
+    ) {
+        if ($draftFunction == null) {
+            $draftFunction = [__CLASS__, 'defaultStateDraftFunction'];
+        }
+        if ($createFunction == null) {
+            $createFunction = [__CLASS__, 'defaultStateCreateFunction'];
+        }
+        if ($deleteFunction == null) {
+            $deleteFunction = [__CLASS__, 'defaultStateDeleteFunction'];
+        }
+
+        parent::withUpdateableDraftResource(
+            $client,
+            $draftBuilderFunction,
+            $assertFunction,
+            $createFunction,
+            $deleteFunction,
+            $draftFunction
+        );
+    }
+
+    final public static function withDraftState(
+        ApiClient $client,
+        callable $draftBuilderFunction,
+        callable $assertFunction,
+        callable $createFunction = null,
+        callable $deleteFunction = null,
+        callable $draftFunction = null
+    ) {
+        if ($draftFunction == null) {
+            $draftFunction = [__CLASS__, 'defaultStateDraftFunction'];
+        }
+        if ($createFunction == null) {
+            $createFunction = [__CLASS__, 'defaultStateCreateFunction'];
+        }
+        if ($deleteFunction == null) {
+            $deleteFunction = [__CLASS__, 'defaultStateDeleteFunction'];
+        }
+
+        parent::withDraftResource(
+            $client,
+            $draftBuilderFunction,
+            $assertFunction,
+            $createFunction,
+            $deleteFunction,
+            $draftFunction
+        );
+    }
+
+    final public static function withState(
+        ApiClient $client,
+        callable $assertFunction,
+        callable $createFunction = null,
+        callable $deleteFunction = null,
+        callable $draftFunction = null
+    ) {
+        self::withDraftState(
+            $client,
+            [__CLASS__, 'defaultStateDraftBuilderFunction'],
+            $assertFunction,
+            $createFunction,
+            $deleteFunction,
+            $draftFunction
+        );
+    }
+
+    final public static function withUpdateableState(
+        ApiClient $client,
+        callable $assertFunction,
+        callable $createFunction = null,
+        callable $deleteFunction = null,
+        callable $draftFunction = null
+    ) {
+        self::withUpdateableDraftState(
+            $client,
+            [__CLASS__, 'defaultStateDraftBuilderFunction'],
+            $assertFunction,
+            $createFunction,
+            $deleteFunction,
+            $draftFunction
+        );
+    }
+}

--- a/tests/integration/State/StateQueryRequestTest.php
+++ b/tests/integration/State/StateQueryRequestTest.php
@@ -3,70 +3,58 @@
  * @author @jenschude <jens.schulze@commercetools.de>
  */
 
-
 namespace Commercetools\Core\IntegrationTests\State;
 
+use Commercetools\Core\Builder\Request\RequestBuilder;
 use Commercetools\Core\IntegrationTests\ApiTestCase;
 use Commercetools\Core\Model\State\State;
 use Commercetools\Core\Model\State\StateDraft;
-use Commercetools\Core\Request\States\StateByIdGetRequest;
-use Commercetools\Core\Request\States\StateCreateRequest;
-use Commercetools\Core\Request\States\StateDeleteRequest;
-use Commercetools\Core\Request\States\StateQueryRequest;
 
 class StateQueryRequestTest extends ApiTestCase
 {
-    /**
-     * @return StateDraft
-     */
-    protected function getDraft()
-    {
-        $draft = StateDraft::ofKeyAndType(
-            'test-' . $this->getTestRun() . '-key',
-            'ProductState'
-        );
-
-        return $draft;
-    }
-
-    protected function createState(StateDraft $draft)
-    {
-        $request = StateCreateRequest::ofDraft($draft);
-        $response = $request->executeWithClient($this->getClient());
-        $state = $request->mapResponse($response);
-
-        $this->cleanupRequests[] = StateDeleteRequest::ofIdAndVersion(
-            $state->getId(),
-            $state->getVersion()
-        );
-
-        return $state;
-    }
+    const PRODUCT_STATE = 'ProductState';
 
     public function testQuery()
     {
-        $draft = $this->getDraft();
-        $state = $this->createState($draft);
+        $client = $this->getApiClient();
 
-        $request = StateQueryRequest::of()->where('key="' . $draft->getKey() . '"');
-        $response = $request->executeWithClient($this->getClient());
-        $result = $request->mapResponse($response);
+        StateFixture::withDraftState(
+            $client,
+            function (StateDraft $draft) {
+                return $draft->setType(self::PRODUCT_STATE);
+            },
+            function (State $state) use ($client) {
+                $request = RequestBuilder::of()->states()->query()
+                ->where('key=:key', ['key' => $state->getKey()]);
 
-        $this->assertCount(1, $result);
-        $this->assertInstanceOf(State::class, $result->getAt(0));
-        $this->assertSame($state->getId(), $result->getAt(0)->getId());
+                $response = $this->execute($client, $request);
+                $result = $request->mapFromResponse($response);
+
+                $this->assertCount(1, $result);
+                $this->assertInstanceOf(State::class, $result->current());
+                $this->assertSame($state->getId(), $result->current()->getId());
+            }
+        );
     }
 
     public function testGetById()
     {
-        $draft = $this->getDraft();
-        $state = $this->createState($draft);
+        $client = $this->getApiClient();
 
-        $request = StateByIdGetRequest::ofId($state->getId());
-        $response = $request->executeWithClient($this->getClient());
-        $result = $request->mapResponse($response);
+        StateFixture::withDraftState(
+            $client,
+            function (StateDraft $draft) {
+                return $draft->setType(self::PRODUCT_STATE);
+            },
+            function (State $state) use ($client) {
+                $request = RequestBuilder::of()->states()->getById($state->getId());
 
-        $this->assertInstanceOf(State::class, $state);
-        $this->assertSame($state->getId(), $result->getId());
+                $response = $this->execute($client, $request);
+                $result = $request->mapFromResponse($response);
+
+                $this->assertInstanceOf(State::class, $result);
+                $this->assertSame($state->getId(), $result->getId());
+            }
+        );
     }
 }

--- a/tests/integration/State/StateUpdateRequestTest.php
+++ b/tests/integration/State/StateUpdateRequestTest.php
@@ -6,6 +6,7 @@
 
 namespace Commercetools\Core\IntegrationTests\State;
 
+use Commercetools\Core\Builder\Request\RequestBuilder;
 use Commercetools\Core\IntegrationTests\ApiTestCase;
 use Commercetools\Core\Model\Common\LocalizedString;
 use Commercetools\Core\Model\State\State;
@@ -26,6 +27,8 @@ use Commercetools\Core\Request\States\StateUpdateRequest;
 
 class StateUpdateRequestTest extends ApiTestCase
 {
+    const REVIEW_STATE = 'ReviewState';
+
     /**
      * @param $key
      * @return StateDraft
@@ -56,141 +59,137 @@ class StateUpdateRequestTest extends ApiTestCase
 
     public function testSetDescription()
     {
-        $draft = $this->getDraft('set-description');
-        $state = $this->createState($draft);
+        $client = $this->getApiClient();
 
+        StateFixture::withDraftState(
+            $client,
+            function (StateDraft $draft) {
+                return $draft->setType(self::REVIEW_STATE)->setInitial(false);
+            },
+            function (State $state) use ($client) {
+                $description = LocalizedString::ofLangAndText('en', 'new-description');
+                $request = RequestBuilder::of()->states()->update($state)
+                    ->addAction(StateSetDescriptionAction::ofDescription($description));
 
-        $description = LocalizedString::ofLangAndText('en', $this->getTestRun() . '-new-description');
-        $request = StateUpdateRequest::ofIdAndVersion(
-            $state->getId(),
-            $state->getVersion()
-        )
-            ->addAction(StateSetDescriptionAction::ofDescription($description))
-        ;
-        $response = $request->executeWithClient($this->getClient());
-        $result = $request->mapResponse($response);
+                $response = $this->execute($client, $request);
+                $result = $request->mapFromResponse($response);
 
-        $this->assertInstanceOf(State::class, $result);
-        $this->assertSame($description->en, $result->getDescription()->en);
-        $this->assertNotSame($state->getVersion(), $result->getVersion());
-
-        $deleteRequest = array_pop($this->cleanupRequests);
-        $deleteRequest->setVersion($result->getVersion());
-        $result = $this->getClient()->execute($deleteRequest)->toObject();
-
-        $this->assertInstanceOf(State::class, $result);
+                $this->assertInstanceOf(State::class, $result);
+                $this->assertSame($description->en, $result->getDescription()->en);
+                $this->assertNotSame($state->getVersion(), $result->getVersion());
+            }
+        );
     }
 
     public function testChangeKey()
     {
-        $draft = $this->getDraft('change-key');
-        $state = $this->createState($draft);
+        $client = $this->getApiClient();
 
+        StateFixture::withDraftState(
+            $client,
+            function (StateDraft $draft) {
+                return $draft->setType(self::REVIEW_STATE)->setInitial(false);
+            },
+            function (State $state) use ($client) {
+                $key = 'new-key';
+                $request = RequestBuilder::of()->states()->update($state)
+                    ->addAction(StateChangeKeyAction::ofKey($key));
 
-        $key = $this->getTestRun() . '-new-key';
-        $request = StateUpdateRequest::ofIdAndVersion(
-            $state->getId(),
-            $state->getVersion()
-        )
-            ->addAction(StateChangeKeyAction::ofKey($key))
-        ;
-        $response = $request->executeWithClient($this->getClient());
-        $result = $request->mapResponse($response);
+                $response = $this->execute($client, $request);
+                $result = $request->mapFromResponse($response);
 
-        $this->assertInstanceOf(State::class, $result);
-        $this->assertSame($key, $result->getKey());
-        $this->assertNotSame($state->getVersion(), $result->getVersion());
-
-        $deleteRequest = array_pop($this->cleanupRequests);
-        $deleteRequest->setVersion($result->getVersion());
-        $result = $this->getClient()->execute($deleteRequest)->toObject();
-
-        $this->assertInstanceOf(State::class, $result);
+                $this->assertInstanceOf(State::class, $result);
+                $this->assertSame($key, $result->getKey());
+                $this->assertNotSame($state->getVersion(), $result->getVersion());
+            }
+        );
     }
 
     public function testSetStateName()
     {
-        $draft = $this->getDraft('set-name');
-        $state = $this->createState($draft);
+        $client = $this->getApiClient();
 
+        StateFixture::withDraftState(
+            $client,
+            function (StateDraft $draft) {
+                return $draft->setType(self::REVIEW_STATE)->setInitial(false);
+            },
+            function (State $state) use ($client) {
+                $name = LocalizedString::ofLangAndText('en', 'new-name');
+                $request = RequestBuilder::of()->states()->update($state)
+                    ->addAction(StateSetNameAction::ofName($name));
 
-        $name = LocalizedString::ofLangAndText('en', $this->getTestRun() . '-new-name');
-        $request = StateUpdateRequest::ofIdAndVersion(
-            $state->getId(),
-            $state->getVersion()
-        )
-            ->addAction(StateSetNameAction::ofName($name))
-        ;
-        $response = $request->executeWithClient($this->getClient());
-        $result = $request->mapResponse($response);
+                $response = $this->execute($client, $request);
+                $result = $request->mapFromResponse($response);
 
-        $this->assertInstanceOf(State::class, $result);
-        $this->assertSame($name->en, $result->getName()->en);
-        $this->assertNotSame($state->getVersion(), $result->getVersion());
-
-        $deleteRequest = array_pop($this->cleanupRequests);
-        $deleteRequest->setVersion($result->getVersion());
-        $result = $this->getClient()->execute($deleteRequest)->toObject();
-
-        $this->assertInstanceOf(State::class, $result);
+                $this->assertInstanceOf(State::class, $result);
+                $this->assertSame($name->en, $result->getName()->en);
+                $this->assertNotSame($state->getVersion(), $result->getVersion());
+            }
+        );
     }
 
     public function testChangeType()
     {
-        $draft = $this->getDraft('change-type');
-        $state = $this->createState($draft);
+        $client = $this->getApiClient();
 
+        StateFixture::withDraftState(
+            $client,
+            function (StateDraft $draft) {
+                return $draft->setType(self::REVIEW_STATE)->setInitial(false);
+            },
+            function (State $state) use ($client) {
+                $type = 'ProductState';
+                $request = RequestBuilder::of()->states()->update($state)
+                    ->addAction(StateChangeTypeAction::ofType($type));
 
-        $type = 'ProductState';
-        $request = StateUpdateRequest::ofIdAndVersion(
-            $state->getId(),
-            $state->getVersion()
-        )
-            ->addAction(StateChangeTypeAction::ofType($type))
-        ;
-        $response = $request->executeWithClient($this->getClient());
-        $result = $request->mapResponse($response);
+                $response = $this->execute($client, $request);
+                $result = $request->mapFromResponse($response);
 
-        $this->assertInstanceOf(State::class, $result);
-        $this->assertSame($type, $result->getType());
-        $this->assertNotSame($state->getVersion(), $result->getVersion());
-
-        $deleteRequest = array_pop($this->cleanupRequests);
-        $deleteRequest->setVersion($result->getVersion());
-        $result = $this->getClient()->execute($deleteRequest)->toObject();
-
-        $this->assertInstanceOf(State::class, $result);
+                $this->assertInstanceOf(State::class, $result);
+                $this->assertSame($type, $result->getType());
+                $this->assertNotSame($state->getVersion(), $result->getVersion());
+            }
+        );
     }
 
     public function testChangeInitial()
     {
-        $draft = $this->getDraft('change-initial');
-        $state = $this->createState($draft);
+        $client = $this->getApiClient();
 
+        StateFixture::withDraftState(
+            $client,
+            function (StateDraft $draft) {
+                return $draft->setType(self::REVIEW_STATE)->setInitial(false);
+            },
+            function (State $state) use ($client) {
+                $initial = true;
+                $request = RequestBuilder::of()->states()->update($state)
+                    ->addAction(StateChangeInitialAction::ofInitial($initial));
 
-        $initial = true;
-        $request = StateUpdateRequest::ofIdAndVersion(
-            $state->getId(),
-            $state->getVersion()
-        )
-            ->addAction(StateChangeInitialAction::ofInitial($initial))
-        ;
-        $response = $request->executeWithClient($this->getClient());
-        $result = $request->mapResponse($response);
+                $response = $this->execute($client, $request);
+                $result = $request->mapFromResponse($response);
 
-        $this->assertInstanceOf(State::class, $result);
-        $this->assertSame($initial, $result->getInitial());
-        $this->assertNotSame($state->getVersion(), $result->getVersion());
-
-        $deleteRequest = array_pop($this->cleanupRequests);
-        $deleteRequest->setVersion($result->getVersion());
-        $result = $this->getClient()->execute($deleteRequest)->toObject();
-
-        $this->assertInstanceOf(State::class, $result);
+                $this->assertInstanceOf(State::class, $result);
+                $this->assertSame($initial, $result->getInitial());
+                $this->assertNotSame($state->getVersion(), $result->getVersion());
+            }
+        );
     }
 
     public function testSetTransition()
     {
+        $client = $this->getApiClient();
+
+        StateFixture::withDraftState(
+            $client,
+            function (StateDraft $draft) {
+                return $draft->setKey('set-transition-1')->setType(self::REVIEW_STATE)->setInitial(false);
+            },
+            function (State $state) use ($client) {
+            }
+        );
+
         $draft = $this->getDraft('set-transition-1');
         $state = $this->createState($draft);
 

--- a/tests/integration/State/StateUpdateRequestTest.php
+++ b/tests/integration/State/StateUpdateRequestTest.php
@@ -38,7 +38,6 @@ class StateUpdateRequestTest extends ApiTestCase
                 $description = LocalizedString::ofLangAndText('en', 'new-description');
                 $request = RequestBuilder::of()->states()->update($state)
                     ->addAction(StateSetDescriptionAction::ofDescription($description));
-
                 $response = $this->execute($client, $request);
                 $result = $request->mapFromResponse($response);
 
@@ -64,7 +63,6 @@ class StateUpdateRequestTest extends ApiTestCase
                 $key = 'new-key';
                 $request = RequestBuilder::of()->states()->update($state)
                     ->addAction(StateChangeKeyAction::ofKey($key));
-
                 $response = $this->execute($client, $request);
                 $result = $request->mapFromResponse($response);
 
@@ -90,7 +88,6 @@ class StateUpdateRequestTest extends ApiTestCase
                 $name = LocalizedString::ofLangAndText('en', 'new-name');
                 $request = RequestBuilder::of()->states()->update($state)
                     ->addAction(StateSetNameAction::ofName($name));
-
                 $response = $this->execute($client, $request);
                 $result = $request->mapFromResponse($response);
 
@@ -116,7 +113,6 @@ class StateUpdateRequestTest extends ApiTestCase
                 $type = 'ProductState';
                 $request = RequestBuilder::of()->states()->update($state)
                     ->addAction(StateChangeTypeAction::ofType($type));
-
                 $response = $this->execute($client, $request);
                 $result = $request->mapFromResponse($response);
 
@@ -142,7 +138,6 @@ class StateUpdateRequestTest extends ApiTestCase
                 $initial = true;
                 $request = RequestBuilder::of()->states()->update($state)
                     ->addAction(StateChangeInitialAction::ofInitial($initial));
-
                 $response = $this->execute($client, $request);
                 $result = $request->mapFromResponse($response);
 
@@ -202,7 +197,6 @@ class StateUpdateRequestTest extends ApiTestCase
                 $roles = ['ReviewIncludedInStatistics'];
                 $request = RequestBuilder::of()->states()->update($state)
                     ->addAction(StateSetRolesAction::ofRoles($roles));
-
                 $response = $this->execute($client, $request);
                 $result = $request->mapFromResponse($response);
 

--- a/tests/integration/Store/StoreDeleteRequestTest.php
+++ b/tests/integration/Store/StoreDeleteRequestTest.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Commercetools\Core\IntegrationTests\Store;
+
+use Commercetools\Core\Builder\Request\RequestBuilder;
+use Commercetools\Core\IntegrationTests\ApiTestCase;
+use Commercetools\Core\Model\Store\Store;
+
+class StoreDeleteRequestTest extends ApiTestCase
+{
+    public function testDeleteByKey()
+    {
+        $client = $this->getApiClient();
+
+        StoreFixture::withStore(
+            $client,
+            function (Store $store) use ($client) {
+                $request = RequestBuilder::of()->stores()->deleteByKey($store);
+                $response = $client->execute($request);
+                $result = $request->mapFromResponse($response);
+
+                $this->assertSame($store->getId(), $result->getId());
+            }
+        );
+    }
+}

--- a/tests/integration/Store/StoreFixture.php
+++ b/tests/integration/Store/StoreFixture.php
@@ -1,49 +1,53 @@
 <?php
 
-namespace Commercetools\Core\IntegrationTests\State;
+namespace Commercetools\Core\IntegrationTests\Store;
 
 use Commercetools\Core\Client\ApiClient;
 use Commercetools\Core\Helper\Uuid;
 use Commercetools\Core\IntegrationTests\ResourceFixture;
-use Commercetools\Core\Model\State\State;
-use Commercetools\Core\Model\State\StateDraft;
-use Commercetools\Core\Request\States\StateCreateRequest;
-use Commercetools\Core\Request\States\StateDeleteRequest;
+use Commercetools\Core\Model\Common\LocalizedString;
+use Commercetools\Core\Model\Store\Store;
+use Commercetools\Core\Model\Store\StoreDraft;
+use Commercetools\Core\Request\Stores\StoreCreateRequest;
+use Commercetools\Core\Request\Stores\StoreDeleteRequest;
 
-class StateFixture extends ResourceFixture
+class StoreFixture extends ResourceFixture
 {
-    const CREATE_REQUEST_TYPE = StateCreateRequest::class;
-    const DELETE_REQUEST_TYPE = StateDeleteRequest::class;
+    const CREATE_REQUEST_TYPE = StoreCreateRequest::class;
+    const DELETE_REQUEST_TYPE = StoreDeleteRequest::class;
 
-    final public static function uniqueStateString()
+    final public static function uniqueStoreString()
     {
         return 'test-' . Uuid::uuidv4();
     }
 
-    final public static function defaultStateDraftFunction()
+    final public static function defaultStoreDraftFunction()
     {
-        $uniqueStateString = self::uniqueStateString();
-        $draft = StateDraft::ofKey('test-' . $uniqueStateString . '-key');
+        $uniqueStoreString = self::uniqueStoreString();
+        $draft = StoreDraft::ofKeyAndName(
+            'key-' . $uniqueStoreString,
+            LocalizedString::ofLangAndText('en', 'test-' . $uniqueStoreString . '-' . 'store-name')
+        );
 
         return $draft;
     }
 
-    final public static function defaultStateDraftBuilderFunction(StateDraft $draft)
+    final public static function defaultStoreDraftBuilderFunction(StoreDraft $draft)
     {
         return $draft;
     }
 
-    final public static function defaultStateCreateFunction(ApiClient $client, StateDraft $draft)
+    final public static function defaultStoreCreateFunction(ApiClient $client, StoreDraft $draft)
     {
         return parent::defaultCreateFunction($client, self::CREATE_REQUEST_TYPE, $draft);
     }
 
-    final public static function defaultStateDeleteFunction(ApiClient $client, State $resource)
+    final public static function defaultStoreDeleteFunction(ApiClient $client, Store $resource)
     {
         return parent::defaultDeleteFunction($client, self::DELETE_REQUEST_TYPE, $resource);
     }
 
-    final public static function withUpdateableDraftState(
+    final public static function withUpdateableDraftStore(
         ApiClient $client,
         callable $draftBuilderFunction,
         callable $assertFunction,
@@ -52,13 +56,13 @@ class StateFixture extends ResourceFixture
         callable $draftFunction = null
     ) {
         if ($draftFunction == null) {
-            $draftFunction = [__CLASS__, 'defaultStateDraftFunction'];
+            $draftFunction = [__CLASS__, 'defaultStoreDraftFunction'];
         }
         if ($createFunction == null) {
-            $createFunction = [__CLASS__, 'defaultStateCreateFunction'];
+            $createFunction = [__CLASS__, 'defaultStoreCreateFunction'];
         }
         if ($deleteFunction == null) {
-            $deleteFunction = [__CLASS__, 'defaultStateDeleteFunction'];
+            $deleteFunction = [__CLASS__, 'defaultStoreDeleteFunction'];
         }
 
         parent::withUpdateableDraftResource(
@@ -71,7 +75,7 @@ class StateFixture extends ResourceFixture
         );
     }
 
-    final public static function withDraftState(
+    final public static function withDraftStore(
         ApiClient $client,
         callable $draftBuilderFunction,
         callable $assertFunction,
@@ -80,13 +84,13 @@ class StateFixture extends ResourceFixture
         callable $draftFunction = null
     ) {
         if ($draftFunction == null) {
-            $draftFunction = [__CLASS__, 'defaultStateDraftFunction'];
+            $draftFunction = [__CLASS__, 'defaultStoreDraftFunction'];
         }
         if ($createFunction == null) {
-            $createFunction = [__CLASS__, 'defaultStateCreateFunction'];
+            $createFunction = [__CLASS__, 'defaultStoreCreateFunction'];
         }
         if ($deleteFunction == null) {
-            $deleteFunction = [__CLASS__, 'defaultStateDeleteFunction'];
+            $deleteFunction = [__CLASS__, 'defaultStoreDeleteFunction'];
         }
 
         parent::withDraftResource(
@@ -99,16 +103,16 @@ class StateFixture extends ResourceFixture
         );
     }
 
-    final public static function withState(
+    final public static function withStore(
         ApiClient $client,
         callable $assertFunction,
         callable $createFunction = null,
         callable $deleteFunction = null,
         callable $draftFunction = null
     ) {
-        self::withDraftState(
+        self::withDraftStore(
             $client,
-            [__CLASS__, 'defaultStateDraftBuilderFunction'],
+            [__CLASS__, 'defaultStoreDraftBuilderFunction'],
             $assertFunction,
             $createFunction,
             $deleteFunction,
@@ -116,16 +120,16 @@ class StateFixture extends ResourceFixture
         );
     }
 
-    final public static function withUpdateableState(
+    final public static function withUpdateableStore(
         ApiClient $client,
         callable $assertFunction,
         callable $createFunction = null,
         callable $deleteFunction = null,
         callable $draftFunction = null
     ) {
-        self::withUpdateableDraftState(
+        self::withUpdateableDraftStore(
             $client,
-            [__CLASS__, 'defaultStateDraftBuilderFunction'],
+            [__CLASS__, 'defaultStoreDraftBuilderFunction'],
             $assertFunction,
             $createFunction,
             $deleteFunction,

--- a/tests/integration/Store/StoreQueryRequestTest.php
+++ b/tests/integration/Store/StoreQueryRequestTest.php
@@ -1,81 +1,64 @@
 <?php
-/**
- */
-
 
 namespace Commercetools\Core\IntegrationTests\Store;
 
+use Commercetools\Core\Builder\Request\RequestBuilder;
 use Commercetools\Core\IntegrationTests\ApiTestCase;
 use Commercetools\Core\Model\Store\Store;
-use Commercetools\Core\Model\Store\StoreDraft;
-use Commercetools\Core\Request\Stores\StoreByIdGetRequest;
-use Commercetools\Core\Request\Stores\StoreByKeyGetRequest;
-use Commercetools\Core\Request\Stores\StoreCreateRequest;
-use Commercetools\Core\Request\Stores\StoreDeleteRequest;
-use Commercetools\Core\Request\Stores\StoreQueryRequest;
 
 class StoreQueryRequestTest extends ApiTestCase
 {
-    /**
-     * @return StoreDraft
-     */
-    protected function getDraft()
-    {
-        return $this->getStoreDraft();
-    }
-
-    protected function createStore(StoreDraft $draft)
-    {
-        $request = StoreCreateRequest::ofDraft($draft);
-        $response = $request->executeWithClient($this->getClient());
-        $store = $request->mapResponse($response);
-
-        $this->cleanupRequests[] = StoreDeleteRequest::ofIdAndVersion(
-            $store->getId(),
-            $store->getVersion()
-        );
-
-        return $store;
-    }
-
     public function testQuery()
     {
-        $draft = $this->getDraft();
-        $store = $this->createStore($draft);
+        $client = $this->getApiClient();
 
-        $request = StoreQueryRequest::of()->where('name(en="' . $draft->getName()->en . '")');
-        $response = $request->executeWithClient($this->getClient());
-        $result = $request->mapResponse($response);
+        StoreFixture::withStore(
+            $client,
+            function (Store $store) use ($client) {
+                $request = RequestBuilder::of()->stores()->query()
+                    ->where('name(en=:name)', ['name' => $store->getName()->en]);
+                $response = $this->execute($client, $request);
+                $result = $request->mapFromResponse($response);
 
-        $this->assertCount(1, $result);
-        $this->assertInstanceOf(Store::class, $result->getAt(0));
-        $this->assertSame($store->getId(), $result->getAt(0)->getId());
+                $this->assertCount(1, $result);
+                $this->assertInstanceOf(Store::class, $result->current());
+                $this->assertSame($store->getId(), $result->current()->getId());
+            }
+        );
     }
 
     public function testGetById()
     {
-        $draft = $this->getDraft();
-        $store = $this->createStore($draft);
+        $client = $this->getApiClient();
 
-        $request = StoreByIdGetRequest::ofId($store->getId());
-        $response = $request->executeWithClient($this->getClient());
-        $result = $request->mapResponse($response);
+        StoreFixture::withStore(
+            $client,
+            function (Store $store) use ($client) {
+                $request = RequestBuilder::of()->stores()->getById($store->getId());
+                $response = $this->execute($client, $request);
+                $result = $request->mapFromResponse($response);
 
-        $this->assertInstanceOf(Store::class, $result);
-        $this->assertSame($store->getId(), $result->getId());
+                $this->assertInstanceOf(Store::class, $result);
+                $this->assertSame($store->getId(), $result->getId());
+            }
+        );
     }
 
     public function testGetByKey()
     {
-        $draft = $this->getDraft();
-        $store = $this->createStore($draft);
+        $client = $this->getApiClient();
 
-        $request = StoreByKeyGetRequest::ofKey($store->getKey());
-        $response = $request->executeWithClient($this->getClient());
-        $result = $request->mapResponse($response);
+        StoreFixture::withStore(
+            $client,
+            function (Store $store) use ($client) {
+                $request = RequestBuilder::of()->stores()->getByKey($store->getKey());
+                $response = $this->execute($client, $request);
+                $result = $request->mapFromResponse($response);
 
-        $this->assertInstanceOf(Store::class, $result);
-        $this->assertSame($store->getId(), $result->getId());
-        $this->assertSame($store->getKey(), $result->getKey());
+                $this->assertInstanceOf(Store::class, $result);
+                $this->assertSame($store->getId(), $result->getId());
+                $this->assertSame($store->getKey(), $result->getKey());
+            }
+        );
     }
 }

--- a/tests/integration/Store/StoreUpdateRequestTest.php
+++ b/tests/integration/Store/StoreUpdateRequestTest.php
@@ -1,70 +1,56 @@
 <?php
-/**
- */
 
 namespace Commercetools\Core\IntegrationTests\Store;
 
+use Commercetools\Core\Builder\Request\RequestBuilder;
 use Commercetools\Core\IntegrationTests\ApiTestCase;
 use Commercetools\Core\Model\Common\LocalizedString;
 use Commercetools\Core\Model\Store\Store;
 use Commercetools\Core\Request\Stores\Command\StoreSetNameAction;
-use Commercetools\Core\Request\Stores\StoreCreateRequest;
-use Commercetools\Core\Request\Stores\StoreDeleteByKeyRequest;
-use Commercetools\Core\Request\Stores\StoreDeleteRequest;
-use Commercetools\Core\Request\Stores\StoreUpdateByKeyRequest;
-use Commercetools\Core\Request\Stores\StoreUpdateRequest;
 
 class StoreUpdateRequestTest extends ApiTestCase
 {
-    protected function createStore($draft)
-    {
-        $request = StoreCreateRequest::ofDraft($draft);
-        $response = $request->executeWithClient($this->getClient());
-        $store = $request->mapResponse($response);
-
-        $this->cleanupRequests[] = $this->deleteRequest = StoreDeleteRequest::ofIdAndVersion(
-            $store->getId(),
-            $store->getVersion()
-        );
-
-        return $store;
-    }
-
     public function testUpdateName()
     {
-        $store = $this->createStore($this->getStoreDraft('store-name'));
+        $client = $this->getApiClient();
 
-        $request = StoreUpdateRequest::ofIdAndVersion($store->getId(), $store->getVersion())
-            ->addAction(StoreSetNameAction::ofName(LocalizedString::ofLangAndText('en', 'another-name')));
-        $response = $request->executeWithClient($this->getClient());
-        $result = $request->mapFromResponse($response);
+        StoreFixture::withUpdateableStore(
+            $client,
+            function (Store $store) use ($client) {
+                $request = RequestBuilder::of()->stores()->update($store)
+                    ->addAction(StoreSetNameAction::ofName(LocalizedString::ofLangAndText('en', 'new-name')));
+                $response = $this->execute($client, $request);
+                $result = $request->mapFromResponse($response);
 
-        $this->deleteRequest->setVersion($result->getVersion());
+                $this->assertInstanceOf(Store::class, $result);
+                $this->assertSame($store->getId(), $result->getId());
+                $this->assertSame('new-name', $result->getName()->en);
+                $this->assertNotSame($store->getVersion(), $result->getVersion());
 
-        $this->assertInstanceOf(Store::class, $result);
-        $this->assertSame($store->getId(), $result->getId());
-        $this->assertSame('another-name', $result->getName()->en);
-        $this->assertNotSame($store->getVersion(), $result->getVersion());
+                return $result;
+            }
+        );
     }
 
-    public function testUpdateAndDeleteByKey()
+    public function testUpdateByKey()
     {
-        $store = $this->createStore($this->getStoreDraft('store-name'));
+        $client = $this->getApiClient();
 
-        $request = StoreUpdateByKeyRequest::ofKeyAndVersion($store->getKey(), $store->getVersion())
-            ->addAction(StoreSetNameAction::ofName(LocalizedString::ofLangAndText('en', 'another-name')));
-        $response = $request->executeWithClient($this->getClient());
-        $result = $request->mapFromResponse($response);
+        StoreFixture::withUpdateableStore(
+            $client,
+            function (Store $store) use ($client) {
+                $request = RequestBuilder::of()->stores()->updateByKey($store)
+                    ->addAction(StoreSetNameAction::ofName(LocalizedString::ofLangAndText('en', 'new-name')));
+                $response = $this->execute($client, $request);
+                $result = $request->mapFromResponse($response);
 
-        $this->assertInstanceOf(Store::class, $result);
-        $this->assertSame($store->getId(), $result->getId());
-        $this->assertSame('another-name', $result->getName()->en);
-        $this->assertNotSame($store->getVersion(), $result->getVersion());
+                $this->assertInstanceOf(Store::class, $result);
+                $this->assertSame($store->getId(), $result->getId());
+                $this->assertSame('new-name', $result->getName()->en);
+                $this->assertNotSame($store->getVersion(), $result->getVersion());
 
-        $deleteRequest = StoreDeleteByKeyRequest::ofKeyAndVersion($result->getKey(), $result->getVersion());
-        $deleteResponse = $deleteRequest->executeWithClient($this->getClient());
-        $deleteResult = $deleteRequest->mapFromResponse($deleteResponse);
-
-        $this->assertInstanceOf(Store::class, $deleteResult);
+                return $result;
+            }
+        );
     }
 }

--- a/tests/integration/Subscription/SubscriptionDeleteRequestTest.php
+++ b/tests/integration/Subscription/SubscriptionDeleteRequestTest.php
@@ -5,14 +5,9 @@
 
 namespace Commercetools\Core\IntegrationTests\Subscription;
 
+use Commercetools\Core\Builder\Request\RequestBuilder;
 use Commercetools\Core\IntegrationTests\ApiTestCase;
-use Commercetools\Core\Model\Subscription\IronMQDestination;
-use Commercetools\Core\Model\Subscription\MessageSubscription;
-use Commercetools\Core\Model\Subscription\MessageSubscriptionCollection;
-use Commercetools\Core\Model\Subscription\SubscriptionDraft;
-use Commercetools\Core\Request\Subscriptions\SubscriptionCreateRequest;
-use Commercetools\Core\Request\Subscriptions\SubscriptionDeleteByKeyRequest;
-use Commercetools\Core\Request\Subscriptions\SubscriptionDeleteRequest;
+use Commercetools\Core\Model\Subscription\Subscription;
 
 class SubscriptionDeleteRequestTest extends ApiTestCase
 {
@@ -24,56 +19,35 @@ class SubscriptionDeleteRequestTest extends ApiTestCase
         }
     }
 
-    /**
-     * @return SubscriptionDraft
-     */
-    protected function getDraft()
-    {
-        $uri = getenv('IRONMQ_URI');
-        $destination = IronMQDestination::ofUri($uri);
-        $messages = MessageSubscriptionCollection::of()->add(MessageSubscription::of()->setResourceTypeId('product'));
-        $key = 'test-' . $this->getTestRun();
-        $draft = SubscriptionDraft::ofKeyDestinationAndMessages($key, $destination, $messages);
-
-        return $draft;
-    }
-
-    protected function createSubscription(SubscriptionDraft $draft)
-    {
-        $request = SubscriptionCreateRequest::ofDraft($draft);
-        $response = $request->executeWithClient($this->getClient());
-        $subscription = $request->mapResponse($response);
-        $this->cleanupRequests[] = $this->deleteRequest = SubscriptionDeleteRequest::ofIdAndVersion(
-            $subscription->getId(),
-            $subscription->getVersion()
-        );
-
-        return $subscription;
-    }
-
     public function testDeleteById()
     {
-        $draft = $this->getDraft();
-        $subscription = $this->createSubscription($draft);
+        $client = $this->getApiClient();
 
-        $request = SubscriptionDeleteRequest::ofIdAndVersion(
-            $subscription->getId(),
-            $subscription->getVersion()
+        SubscriptionFixture::withSubscription(
+            $client,
+            function (Subscription $subscription) use ($client) {
+                $request = RequestBuilder::of()->subscriptions()->delete($subscription);
+                $response = $client->execute($request);
+                $result = $request->mapFromResponse($response);
+
+                $this->assertSame($subscription->getId(), $result->getId());
+            }
         );
-        $response = $request->executeWithClient($this->getClient());
-        $this->assertFalse($response->isError());
     }
 
     public function testDeleteByKey()
     {
-        $draft = $this->getDraft();
-        $subscription = $this->createSubscription($draft);
+        $client = $this->getApiClient();
 
-        $request = SubscriptionDeleteByKeyRequest::ofKeyAndVersion(
-            $subscription->getKey(),
-            $subscription->getVersion()
+        SubscriptionFixture::withSubscription(
+            $client,
+            function (Subscription $subscription) use ($client) {
+                $request = RequestBuilder::of()->subscriptions()->deleteByKey($subscription);
+                $response = $client->execute($request);
+                $result = $request->mapFromResponse($response);
+
+                $this->assertSame($subscription->getId(), $result->getId());
+            }
         );
-        $response = $request->executeWithClient($this->getClient());
-        $this->assertFalse($response->isError());
     }
 }

--- a/tests/integration/Subscription/SubscriptionFixture.php
+++ b/tests/integration/Subscription/SubscriptionFixture.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace Commercetools\Core\IntegrationTests\Subscription;
+
+use Commercetools\Core\Client\ApiClient;
+use Commercetools\Core\Helper\Uuid;
+use Commercetools\Core\IntegrationTests\ResourceFixture;
+use Commercetools\Core\Model\Subscription\Destination;
+use Commercetools\Core\Model\Subscription\MessageSubscription;
+use Commercetools\Core\Model\Subscription\MessageSubscriptionCollection;
+use Commercetools\Core\Model\Subscription\Subscription;
+use Commercetools\Core\Model\Subscription\SubscriptionDraft;
+use Commercetools\Core\Request\Subscriptions\SubscriptionCreateRequest;
+use Commercetools\Core\Request\Subscriptions\SubscriptionDeleteRequest;
+
+class SubscriptionFixture extends ResourceFixture
+{
+    const CREATE_REQUEST_TYPE = SubscriptionCreateRequest::class;
+    const DELETE_REQUEST_TYPE = SubscriptionDeleteRequest::class;
+
+    final public static function uniqueSubscriptionString()
+    {
+        return 'test-' . Uuid::uuidv4();
+    }
+
+    final public static function defaultSubscriptionDraftFunction()
+    {
+        $uniqueSubscriptionString = self::uniqueSubscriptionString();
+        $uri = getenv('IRONMQ_URI');
+        $destination = Destination::ofUri($uri);
+        $messages = MessageSubscriptionCollection::of()->add(MessageSubscription::of()->setResourceTypeId('product'));
+        $key = 'test-' . $uniqueSubscriptionString;
+        $draft = SubscriptionDraft::ofKeyDestinationAndMessages($key, $destination, $messages);
+
+        return $draft;
+    }
+
+    final public static function defaultSubscriptionDraftBuilderFunction(SubscriptionDraft $draft)
+    {
+        return $draft;
+    }
+
+    final public static function defaultSubscriptionCreateFunction(ApiClient $client, SubscriptionDraft $draft)
+    {
+        return parent::defaultCreateFunction($client, self::CREATE_REQUEST_TYPE, $draft);
+    }
+
+    final public static function defaultSubscriptionDeleteFunction(ApiClient $client, Subscription $resource)
+    {
+        return parent::defaultDeleteFunction($client, self::DELETE_REQUEST_TYPE, $resource);
+    }
+
+    final public static function withUpdateableDraftSubscription(
+        ApiClient $client,
+        callable $draftBuilderFunction,
+        callable $assertFunction,
+        callable $createFunction = null,
+        callable $deleteFunction = null,
+        callable $draftFunction = null
+    ) {
+        if ($draftFunction == null) {
+            $draftFunction = [__CLASS__, 'defaultSubscriptionDraftFunction'];
+        }
+        if ($createFunction == null) {
+            $createFunction = [__CLASS__, 'defaultSubscriptionCreateFunction'];
+        }
+        if ($deleteFunction == null) {
+            $deleteFunction = [__CLASS__, 'defaultSubscriptionDeleteFunction'];
+        }
+
+        parent::withUpdateableDraftResource(
+            $client,
+            $draftBuilderFunction,
+            $assertFunction,
+            $createFunction,
+            $deleteFunction,
+            $draftFunction
+        );
+    }
+
+    final public static function withDraftSubscription(
+        ApiClient $client,
+        callable $draftBuilderFunction,
+        callable $assertFunction,
+        callable $createFunction = null,
+        callable $deleteFunction = null,
+        callable $draftFunction = null
+    ) {
+        if ($draftFunction == null) {
+            $draftFunction = [__CLASS__, 'defaultSubscriptionDraftFunction'];
+        }
+        if ($createFunction == null) {
+            $createFunction = [__CLASS__, 'defaultSubscriptionCreateFunction'];
+        }
+        if ($deleteFunction == null) {
+            $deleteFunction = [__CLASS__, 'defaultSubscriptionDeleteFunction'];
+        }
+
+        parent::withDraftResource(
+            $client,
+            $draftBuilderFunction,
+            $assertFunction,
+            $createFunction,
+            $deleteFunction,
+            $draftFunction
+        );
+    }
+
+    final public static function withSubscription(
+        ApiClient $client,
+        callable $assertFunction,
+        callable $createFunction = null,
+        callable $deleteFunction = null,
+        callable $draftFunction = null
+    ) {
+        self::withDraftSubscription(
+            $client,
+            [__CLASS__, 'defaultSubscriptionDraftBuilderFunction'],
+            $assertFunction,
+            $createFunction,
+            $deleteFunction,
+            $draftFunction
+        );
+    }
+
+    final public static function withUpdateableSubscription(
+        ApiClient $client,
+        callable $assertFunction,
+        callable $createFunction = null,
+        callable $deleteFunction = null,
+        callable $draftFunction = null
+    ) {
+        self::withUpdateableDraftSubscription(
+            $client,
+            [__CLASS__, 'defaultSubscriptionDraftBuilderFunction'],
+            $assertFunction,
+            $createFunction,
+            $deleteFunction,
+            $draftFunction
+        );
+    }
+}

--- a/tests/integration/Subscription/SubscriptionUpdateRequestTest.php
+++ b/tests/integration/Subscription/SubscriptionUpdateRequestTest.php
@@ -3,27 +3,18 @@
  * @author @jenschude <jens.schulze@commercetools.de>
  */
 
-
 namespace Commercetools\Core\IntegrationTests\Subscription;
 
+use Commercetools\Core\Builder\Request\RequestBuilder;
 use Commercetools\Core\IntegrationTests\ApiTestCase;
 use Commercetools\Core\Model\Subscription\ChangeSubscription;
 use Commercetools\Core\Model\Subscription\ChangeSubscriptionCollection;
-use Commercetools\Core\Model\Subscription\IronMQDestination;
 use Commercetools\Core\Model\Subscription\MessageSubscription;
 use Commercetools\Core\Model\Subscription\MessageSubscriptionCollection;
 use Commercetools\Core\Model\Subscription\Subscription;
-use Commercetools\Core\Model\Subscription\SubscriptionDraft;
 use Commercetools\Core\Request\Subscriptions\Command\SubscriptionSetChangesAction;
 use Commercetools\Core\Request\Subscriptions\Command\SubscriptionSetKeyAction;
 use Commercetools\Core\Request\Subscriptions\Command\SubscriptionSetMessagesAction;
-use Commercetools\Core\Request\Subscriptions\SubscriptionByIdGetRequest;
-use Commercetools\Core\Request\Subscriptions\SubscriptionByKeyGetRequest;
-use Commercetools\Core\Request\Subscriptions\SubscriptionCreateRequest;
-use Commercetools\Core\Request\Subscriptions\SubscriptionDeleteRequest;
-use Commercetools\Core\Request\Subscriptions\SubscriptionQueryRequest;
-use Commercetools\Core\Request\Subscriptions\SubscriptionUpdateByKeyRequest;
-use Commercetools\Core\Request\Subscriptions\SubscriptionUpdateRequest;
 
 class SubscriptionUpdateRequestTest extends ApiTestCase
 {
@@ -35,136 +26,122 @@ class SubscriptionUpdateRequestTest extends ApiTestCase
         }
     }
 
-    /**
-     * @return SubscriptionDraft
-     */
-    protected function getDraft()
-    {
-        $uri = getenv('IRONMQ_URI');
-        $destination = IronMQDestination::ofUri($uri);
-        $messages = MessageSubscriptionCollection::of()->add(MessageSubscription::of()->setResourceTypeId('product'));
-        $key = 'test-' . $this->getTestRun();
-        $draft = SubscriptionDraft::ofKeyDestinationAndMessages($key, $destination, $messages);
-
-        return $draft;
-    }
-
-    protected function createSubscription(SubscriptionDraft $draft)
-    {
-        $request = SubscriptionCreateRequest::ofDraft($draft);
-        $response = $request->executeWithClient($this->getClient());
-        $subscription = $request->mapResponse($response);
-        $this->cleanupRequests[] = $this->deleteRequest = SubscriptionDeleteRequest::ofIdAndVersion(
-            $subscription->getId(),
-            $subscription->getVersion()
-        );
-
-        return $subscription;
-    }
-
     public function testUpdateByKey()
     {
-        $draft = $this->getDraft();
-        $subscription = $this->createSubscription($draft);
+        $client = $this->getApiClient();
 
-        $request = SubscriptionUpdateByKeyRequest::ofKeyAndVersion(
-            $subscription->getKey(),
-            $subscription->getVersion()
+        SubscriptionFixture::withUpdateableSubscription(
+            $client,
+            function (Subscription $subscription) use ($client) {
+                $request = RequestBuilder::of()->subscriptions()->updateByKey($subscription);
+                $response = $this->execute($client, $request);
+                $result = $request->mapFromResponse($response);
+
+                $this->assertInstanceOf(Subscription::class, $result);
+                $this->assertSame($subscription->getId(), $result->getId());
+                $this->assertNotSame($subscription->getVersion(), $result->getVersion());
+
+                return $result;
+            }
         );
-        $response = $request->executeWithClient($this->getClient());
-        $result = $request->mapResponse($response);
-        $this->deleteRequest->setVersion($result->getVersion());
-
-        $this->assertInstanceOf(Subscription::class, $result);
     }
 
     public function testUpdateById()
     {
-        $draft = $this->getDraft();
-        $subscription = $this->createSubscription($draft);
+        $client = $this->getApiClient();
 
-        $request = SubscriptionUpdateRequest::ofIdAndVersion(
-            $subscription->getId(),
-            $subscription->getVersion()
+        SubscriptionFixture::withUpdateableSubscription(
+            $client,
+            function (Subscription $subscription) use ($client) {
+                $request = RequestBuilder::of()->subscriptions()->update($subscription);
+                $response = $this->execute($client, $request);
+                $result = $request->mapFromResponse($response);
+
+                $this->assertInstanceOf(Subscription::class, $result);
+                $this->assertSame($subscription->getId(), $result->getId());
+                $this->assertNotSame($subscription->getVersion(), $result->getVersion());
+
+                return $result;
+            }
         );
-        $response = $request->executeWithClient($this->getClient());
-        $result = $request->mapResponse($response);
-        $this->deleteRequest->setVersion($result->getVersion());
-
-        $this->assertInstanceOf(Subscription::class, $result);
     }
 
     public function testUpdateKey()
     {
-        $draft = $this->getDraft();
-        $subscription = $this->createSubscription($draft);
+        $client = $this->getApiClient();
 
-        $request = SubscriptionUpdateRequest::ofIdAndVersion(
-            $subscription->getId(),
-            $subscription->getVersion()
+        SubscriptionFixture::withUpdateableSubscription(
+            $client,
+            function (Subscription $subscription) use ($client) {
+                $request = RequestBuilder::of()->subscriptions()->update($subscription);
+                $response = $this->execute($client, $request);
+                $result = $request->mapFromResponse($response);
+
+                $key = $this->getTestRun() . '-new';
+                $request = RequestBuilder::of()->subscriptions()->update($subscription)
+                    ->addAction(SubscriptionSetKeyAction::of()->setKey($key));
+                $response = $this->execute($client, $request);
+                $result = $request->mapFromResponse($response);
+
+                $this->assertInstanceOf(Subscription::class, $result);
+                $this->assertSame($key, $result->getKey());
+
+                return $result;
+            }
         );
-
-        $key = $this->getTestRun() . '-new';
-        $request->addAction(
-            SubscriptionSetKeyAction::of()->setKey($key)
-        );
-        $response = $request->executeWithClient($this->getClient());
-        $result = $request->mapResponse($response);
-        $this->deleteRequest->setVersion($result->getVersion());
-
-        $this->assertInstanceOf(Subscription::class, $result);
-        $this->assertSame($key, $result->getKey());
     }
 
     public function testUpdateMessages()
     {
-        $draft = $this->getDraft();
-        $subscription = $this->createSubscription($draft);
+        $client = $this->getApiClient();
 
-        $request = SubscriptionUpdateRequest::ofIdAndVersion(
-            $subscription->getId(),
-            $subscription->getVersion()
+        SubscriptionFixture::withUpdateableSubscription(
+            $client,
+            function (Subscription $subscription) use ($client) {
+                $request = RequestBuilder::of()->subscriptions()->update($subscription)
+                    ->addAction(
+                        SubscriptionSetMessagesAction::of()->setMessages(
+                            MessageSubscriptionCollection::of()->add(
+                                MessageSubscription::of()->setResourceTypeId('order')
+                            )
+                        )
+                    );
+                $response = $this->execute($client, $request);
+                $result = $request->mapFromResponse($response);
+
+                $this->assertInstanceOf(Subscription::class, $result);
+                $this->assertCount(1, $result->getMessages());
+                $this->assertSame('order', $result->getMessages()->current()->getResourceTypeId());
+
+                return $result;
+            }
         );
-
-        $request->addAction(
-            SubscriptionSetMessagesAction::of()->setMessages(
-                MessageSubscriptionCollection::of()->add(
-                    MessageSubscription::of()->setResourceTypeId('order')
-                )
-            )
-        );
-        $response = $request->executeWithClient($this->getClient());
-        $result = $request->mapResponse($response);
-        $this->deleteRequest->setVersion($result->getVersion());
-
-        $this->assertInstanceOf(Subscription::class, $result);
-        $this->assertCount(1, $result->getMessages());
-        $this->assertSame('order', $result->getMessages()->current()->getResourceTypeId());
     }
 
     public function testUpdateChanges()
     {
-        $draft = $this->getDraft();
-        $subscription = $this->createSubscription($draft);
+        $client = $this->getApiClient();
 
-        $request = SubscriptionUpdateRequest::ofIdAndVersion(
-            $subscription->getId(),
-            $subscription->getVersion()
+        SubscriptionFixture::withUpdateableSubscription(
+            $client,
+            function (Subscription $subscription) use ($client) {
+                $request = RequestBuilder::of()->subscriptions()->update($subscription)
+                    ->addAction(
+                        SubscriptionSetChangesAction::of()->setChanges(
+                            ChangeSubscriptionCollection::of()->add(
+                                ChangeSubscription::of()->setResourceTypeId('product')
+                            )
+                        )
+                    );
+                $response = $this->execute($client, $request);
+                $result = $request->mapFromResponse($response);
+
+                $this->assertInstanceOf(Subscription::class, $result);
+                $this->assertCount(1, $result->getMessages());
+                $this->assertSame('product', $result->getChanges()->current()->getResourceTypeId());
+
+                return $result;
+            }
         );
-
-        $request->addAction(
-            SubscriptionSetChangesAction::of()->setChanges(
-                ChangeSubscriptionCollection::of()->add(
-                    ChangeSubscription::of()->setResourceTypeId('product')
-                )
-            )
-        );
-        $response = $request->executeWithClient($this->getClient());
-        $result = $request->mapResponse($response);
-        $this->deleteRequest->setVersion($result->getVersion());
-
-        $this->assertInstanceOf(Subscription::class, $result);
-        $this->assertCount(1, $result->getMessages());
-        $this->assertSame('product', $result->getChanges()->current()->getResourceTypeId());
     }
 }

--- a/tests/integration/TaxCategory/TaxCategoryFixture.php
+++ b/tests/integration/TaxCategory/TaxCategoryFixture.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace Commercetools\Core\IntegrationTests\TaxCategory;
+
+use Commercetools\Core\Client\ApiClient;
+use Commercetools\Core\Helper\Uuid;
+use Commercetools\Core\IntegrationTests\ResourceFixture;
+use Commercetools\Core\Model\TaxCategory\TaxCategory;
+use Commercetools\Core\Model\TaxCategory\TaxCategoryDraft;
+use Commercetools\Core\Model\TaxCategory\TaxRate;
+use Commercetools\Core\Model\TaxCategory\TaxRateCollection;
+use Commercetools\Core\Request\TaxCategories\TaxCategoryCreateRequest;
+use Commercetools\Core\Request\TaxCategories\TaxCategoryDeleteRequest;
+
+class TaxCategoryFixture extends ResourceFixture
+{
+    const CREATE_REQUEST_TYPE = TaxCategoryCreateRequest::class;
+    const DELETE_REQUEST_TYPE = TaxCategoryDeleteRequest::class;
+    const RAND_MAX = 10000;
+
+    final public static function uniqueTaxCategoryString()
+    {
+        return 'test-' . Uuid::uuidv4();
+    }
+
+    final public static function defaultTaxCategoryDraftFunction()
+    {
+        $uniqueTaxCategoryString = self::uniqueTaxCategoryString();
+        $region = "r" . (string)mt_rand(1, static::RAND_MAX);
+
+        $draft = TaxCategoryDraft::ofNameAndRates(
+            'test-' . $uniqueTaxCategoryString . '-name',
+            TaxRateCollection::of()->add(
+                TaxRate::of()->setName('test-' . $uniqueTaxCategoryString . '-name')
+                    ->setAmount(0.2)
+                    ->setIncludedInPrice(true)
+                    ->setCountry('DE')
+                    ->setState($region)
+            )
+        );
+
+        return $draft;
+    }
+
+    final public static function defaultTaxCategoryDraftBuilderFunction(TaxCategoryDraft $draft)
+    {
+        return $draft;
+    }
+
+    final public static function defaultTaxCategoryCreateFunction(ApiClient $client, TaxCategoryDraft $draft)
+    {
+        return parent::defaultCreateFunction($client, self::CREATE_REQUEST_TYPE, $draft);
+    }
+
+    final public static function defaultTaxCategoryDeleteFunction(ApiClient $client, TaxCategory $resource)
+    {
+        return parent::defaultDeleteFunction($client, self::DELETE_REQUEST_TYPE, $resource);
+    }
+
+    final public static function withUpdateableDraftTaxCategory(
+        ApiClient $client,
+        callable $draftBuilderFunction,
+        callable $assertFunction,
+        callable $createFunction = null,
+        callable $deleteFunction = null,
+        callable $draftFunction = null
+    ) {
+        if ($draftFunction == null) {
+            $draftFunction = [__CLASS__, 'defaultTaxCategoryDraftFunction'];
+        }
+        if ($createFunction == null) {
+            $createFunction = [__CLASS__, 'defaultTaxCategoryCreateFunction'];
+        }
+        if ($deleteFunction == null) {
+            $deleteFunction = [__CLASS__, 'defaultTaxCategoryDeleteFunction'];
+        }
+
+        parent::withUpdateableDraftResource(
+            $client,
+            $draftBuilderFunction,
+            $assertFunction,
+            $createFunction,
+            $deleteFunction,
+            $draftFunction
+        );
+    }
+
+    final public static function withDraftTaxCategory(
+        ApiClient $client,
+        callable $draftBuilderFunction,
+        callable $assertFunction,
+        callable $createFunction = null,
+        callable $deleteFunction = null,
+        callable $draftFunction = null
+    ) {
+        if ($draftFunction == null) {
+            $draftFunction = [__CLASS__, 'defaultTaxCategoryDraftFunction'];
+        }
+        if ($createFunction == null) {
+            $createFunction = [__CLASS__, 'defaultTaxCategoryCreateFunction'];
+        }
+        if ($deleteFunction == null) {
+            $deleteFunction = [__CLASS__, 'defaultTaxCategoryDeleteFunction'];
+        }
+
+        parent::withDraftResource(
+            $client,
+            $draftBuilderFunction,
+            $assertFunction,
+            $createFunction,
+            $deleteFunction,
+            $draftFunction
+        );
+    }
+
+    final public static function withTaxCategory(
+        ApiClient $client,
+        callable $assertFunction,
+        callable $createFunction = null,
+        callable $deleteFunction = null,
+        callable $draftFunction = null
+    ) {
+        self::withDraftTaxCategory(
+            $client,
+            [__CLASS__, 'defaultTaxCategoryDraftBuilderFunction'],
+            $assertFunction,
+            $createFunction,
+            $deleteFunction,
+            $draftFunction
+        );
+    }
+
+    final public static function withUpdateableTaxCategory(
+        ApiClient $client,
+        callable $assertFunction,
+        callable $createFunction = null,
+        callable $deleteFunction = null,
+        callable $draftFunction = null
+    ) {
+        self::withUpdateableDraftTaxCategory(
+            $client,
+            [__CLASS__, 'defaultTaxCategoryDraftBuilderFunction'],
+            $assertFunction,
+            $createFunction,
+            $deleteFunction,
+            $draftFunction
+        );
+    }
+}

--- a/tests/integration/TaxCategory/TaxCategoryQueryRequestTest.php
+++ b/tests/integration/TaxCategory/TaxCategoryQueryRequestTest.php
@@ -3,109 +3,89 @@
  * @author @jenschude <jens.schulze@commercetools.de>
  */
 
-
 namespace Commercetools\Core\IntegrationTests\TaxCategory;
 
+use Commercetools\Core\Builder\Request\RequestBuilder;
 use Commercetools\Core\IntegrationTests\ApiTestCase;
 use Commercetools\Core\Model\TaxCategory\TaxCategory;
 use Commercetools\Core\Model\TaxCategory\TaxCategoryDraft;
-use Commercetools\Core\Model\TaxCategory\TaxRate;
-use Commercetools\Core\Model\TaxCategory\TaxRateCollection;
-use Commercetools\Core\Request\TaxCategories\TaxCategoryByIdGetRequest;
-use Commercetools\Core\Request\TaxCategories\TaxCategoryByKeyGetRequest;
-use Commercetools\Core\Request\TaxCategories\TaxCategoryCreateRequest;
-use Commercetools\Core\Request\TaxCategories\TaxCategoryDeleteByKeyRequest;
-use Commercetools\Core\Request\TaxCategories\TaxCategoryDeleteRequest;
-use Commercetools\Core\Request\TaxCategories\TaxCategoryQueryRequest;
 
 class TaxCategoryQueryRequestTest extends ApiTestCase
 {
-    /**
-     * @return TaxCategoryDraft
-     */
-    protected function getDraft()
-    {
-        $draft = TaxCategoryDraft::ofNameAndRates(
-            'test-' . $this->getTestRun() . '-name',
-            TaxRateCollection::of()->add(
-                TaxRate::of()->setName('test-' . $this->getTestRun() . '-name')
-                    ->setAmount(0.2)
-                    ->setIncludedInPrice(true)
-                    ->setCountry('DE')
-                    ->setState($this->getRegion())
-            )
-        );
-
-        return $draft;
-    }
-
-    protected function createTaxCategory(TaxCategoryDraft $draft)
-    {
-        $request = TaxCategoryCreateRequest::ofDraft($draft);
-        $response = $request->executeWithClient($this->getClient());
-        $taxCategory = $request->mapResponse($response);
-
-        $this->cleanupRequests[] = TaxCategoryDeleteRequest::ofIdAndVersion(
-            $taxCategory->getId(),
-            $taxCategory->getVersion()
-        );
-
-        return $taxCategory;
-    }
-
     public function testQuery()
     {
-        $draft = $this->getDraft();
-        $taxCategory = $this->createTaxCategory($draft);
+        $client = $this->getApiClient();
 
-        $request = TaxCategoryQueryRequest::of()->where('name="' . $draft->getName() . '"');
-        $response = $request->executeWithClient($this->getClient());
-        $result = $request->mapResponse($response);
+        TaxCategoryFixture::withTaxCategory(
+            $client,
+            function (TaxCategory $taxCategory) use ($client) {
+                $request = RequestBuilder::of()->taxCategories()->query()
+                    ->where('name=:name', ['name' => $taxCategory->getName()]);
+                $response = $this->execute($client, $request);
+                $result = $request->mapFromResponse($response);
 
-        $this->assertCount(1, $result);
-        $this->assertInstanceOf(TaxCategory::class, $result->getAt(0));
-        $this->assertSame($taxCategory->getId(), $result->getAt(0)->getId());
+                $this->assertCount(1, $result);
+                $this->assertInstanceOf(TaxCategory::class, $result->current());
+                $this->assertSame($taxCategory->getId(), $result->current()->getId());
+            }
+        );
     }
 
     public function testGetById()
     {
-        $draft = $this->getDraft();
-        $taxCategory = $this->createTaxCategory($draft);
+        $client = $this->getApiClient();
 
-        $request = TaxCategoryByIdGetRequest::ofId($taxCategory->getId());
-        $response = $request->executeWithClient($this->getClient());
-        $result = $request->mapResponse($response);
+        TaxCategoryFixture::withTaxCategory(
+            $client,
+            function (TaxCategory $taxCategory) use ($client) {
+                $request = RequestBuilder::of()->taxCategories()->getById($taxCategory->getId());
+                $response = $this->execute($client, $request);
+                $result = $request->mapFromResponse($response);
 
-        $this->assertInstanceOf(TaxCategory::class, $taxCategory);
-        $this->assertSame($taxCategory->getId(), $result->getId());
+                $this->assertInstanceOf(TaxCategory::class, $taxCategory);
+                $this->assertSame($taxCategory->getId(), $result->getId());
+            }
+        );
     }
 
     public function testGetByKey()
     {
-        $draft = $this->getDraft()->setKey($this->getTestRun());
-        $taxCategory = $this->createTaxCategory($draft);
+        $client = $this->getApiClient();
 
-        $request = TaxCategoryByKeyGetRequest::ofKey($taxCategory->getKey());
-        $response = $request->executeWithClient($this->getClient());
-        $result = $request->mapResponse($response);
+        TaxCategoryFixture::withDraftTaxCategory(
+            $client,
+            function (TaxCategoryDraft $draft) {
+                return $draft->setKey('set-key');
+            },
+            function (TaxCategory $taxCategory) use ($client) {
+                $request = RequestBuilder::of()->taxCategories()->getByKey($taxCategory->getKey());
+                $response = $this->execute($client, $request);
+                $result = $request->mapFromResponse($response);
 
-        $this->assertInstanceOf(TaxCategory::class, $taxCategory);
-        $this->assertSame($taxCategory->getId(), $result->getId());
+                $this->assertInstanceOf(TaxCategory::class, $taxCategory);
+                $this->assertSame($taxCategory->getId(), $result->getId());
+                $this->assertSame($taxCategory->getKey(), $result->getKey());
+            }
+        );
     }
 
 
     public function testDeleteByKey()
     {
-        $draft = $this->getDraft()->setKey($this->getTestRun());
-        $taxCategory = $this->createTaxCategory($draft);
+        $client = $this->getApiClient();
 
-        $request = TaxCategoryDeleteByKeyRequest::ofKeyAndVersion(
-            $taxCategory->getKey(),
-            $taxCategory->getVersion()
+        TaxCategoryFixture::withDraftTaxCategory(
+            $client,
+            function (TaxCategoryDraft $draft) {
+                return $draft->setKey($this->getTestRun());
+            },
+            function (TaxCategory $taxCategory) use ($client) {
+                $request = RequestBuilder::of()->taxCategories()->deleteByKey($taxCategory);
+                $response = $this->execute($client, $request);
+                $result = $request->mapFromResponse($response);
+
+                $this->assertSame($taxCategory->getId(), $result->getId());
+            }
         );
-        $result = $this->getClient()->execute($request);
-        $response = $request->mapFromResponse($result);
-
-        $this->assertSame($taxCategory->getId(), $response->getId());
     }
 }

--- a/tests/integration/TaxCategory/TaxCategoryUpdateRequestTest.php
+++ b/tests/integration/TaxCategory/TaxCategoryUpdateRequestTest.php
@@ -3,213 +3,187 @@
  * @author @jenschude <jens.schulze@commercetools.de>
  */
 
-
 namespace Commercetools\Core\IntegrationTests\TaxCategory;
 
+use Commercetools\Core\Builder\Request\RequestBuilder;
 use Commercetools\Core\IntegrationTests\ApiTestCase;
 use Commercetools\Core\Model\TaxCategory\TaxCategory;
 use Commercetools\Core\Model\TaxCategory\TaxCategoryDraft;
 use Commercetools\Core\Model\TaxCategory\TaxRate;
-use Commercetools\Core\Model\TaxCategory\TaxRateCollection;
 use Commercetools\Core\Request\TaxCategories\Command\TaxCategoryAddTaxRateAction;
 use Commercetools\Core\Request\TaxCategories\Command\TaxCategoryChangeNameAction;
 use Commercetools\Core\Request\TaxCategories\Command\TaxCategoryRemoveTaxRateAction;
 use Commercetools\Core\Request\TaxCategories\Command\TaxCategoryReplaceTaxRateAction;
 use Commercetools\Core\Request\TaxCategories\Command\TaxCategorySetDescriptionAction;
 use Commercetools\Core\Request\TaxCategories\Command\TaxCategorySetKeyAction;
-use Commercetools\Core\Request\TaxCategories\TaxCategoryCreateRequest;
-use Commercetools\Core\Request\TaxCategories\TaxCategoryDeleteRequest;
-use Commercetools\Core\Request\TaxCategories\TaxCategoryUpdateRequest;
-use Commercetools\Core\Request\TaxCategories\TaxCategoryUpdateByKeyRequest;
-use function GuzzleHttp\Psr7\str;
 
 class TaxCategoryUpdateRequestTest extends ApiTestCase
 {
-    /**
-     * @var $name
-     * @return TaxCategoryDraft
-     */
-    protected function getDraft($name)
+
+    private function getTaxRate()
     {
-        $draft = TaxCategoryDraft::ofNameAndRates(
-            'test-' . $this->getTestRun() . '-' . $name,
-            TaxRateCollection::of()->add(
-                TaxRate::of()->setName('test-' . $this->getTestRun() . '-name')
-                    ->setAmount(0.2)
-                    ->setIncludedInPrice(true)
-                    ->setCountry('DE')
-                    ->setState($this->getRegion())
-            )
-        );
-
-        return $draft;
-    }
-
-    protected function createTaxCategory(TaxCategoryDraft $draft)
-    {
-        $request = TaxCategoryCreateRequest::ofDraft($draft);
-        $response = $request->executeWithClient($this->getClient());
-        $taxCategory = $request->mapResponse($response);
-
-        $this->cleanupRequests[] = $this->deleteRequest = TaxCategoryDeleteRequest::ofIdAndVersion(
-            $taxCategory->getId(),
-            $taxCategory->getVersion()
-        );
-
-        return $taxCategory;
-    }
-
-    public function testChangeName()
-    {
-        $draft = $this->getDraft('change-name');
-        $taxCategory = $this->createTaxCategory($draft);
-
-
-        $name = $this->getTestRun() . '-new-name';
-        $request = TaxCategoryUpdateRequest::ofIdAndVersion(
-            $taxCategory->getId(),
-            $taxCategory->getVersion()
-        )
-            ->addAction(TaxCategoryChangeNameAction::ofName($name))
-        ;
-        $response = $request->executeWithClient($this->getClient());
-        $result = $request->mapResponse($response);
-        $this->deleteRequest->setVersion($result->getVersion());
-
-        $this->assertInstanceOf(TaxCategory::class, $result);
-        $this->assertSame($name, $result->getName());
-        $this->assertNotSame($taxCategory->getVersion(), $result->getVersion());
-    }
-
-    public function testUpdateNameByKey()
-    {
-        $draft = $this->getDraft('update name')->setKey('key-' . $this->getTestRun());
-        $taxCategory = $this->createTaxCategory($draft);
-
-        $name = $this->getTestRun() . '-new-name';
-        $request = TaxCategoryUpdateByKeyRequest::ofKeyAndVersion($taxCategory->getKey(), $taxCategory->getVersion())
-            ->addAction(TaxCategoryChangeNameAction::ofName($name));
-
-        $response = $request->executeWithClient($this->getClient());
-        $result = $request->mapResponse($response);
-        $this->deleteRequest->setVersion($result->getVersion());
-
-        $this->assertInstanceOf(TaxCategory::class, $result);
-        $this->assertSame($name, $result->getName());
-        $this->assertNotSame($taxCategory->getVersion(), $result->getVersion());
-    }
-
-    public function testSetKey()
-    {
-        $draft = $this->getDraft('set-key');
-        $taxCategory = $this->createTaxCategory($draft);
-
-        $key = $this->getTestRun() . '-new-key';
-        $request = TaxCategoryUpdateRequest::ofIdAndVersion($taxCategory->getId(), $taxCategory->getVersion())
-            ->addAction(
-                TaxCategorySetKeyAction::ofKey($key)
-            )
-        ;
-        $response = $request->executeWithClient($this->getClient());
-        $result = $request->mapResponse($response);
-
-        $this->deleteRequest->setVersion($result->getVersion());
-
-        $this->assertInstanceOf(TaxCategory::class, $result);
-        $this->assertNotSame($key, $draft->getKey());
-        $this->assertSame($key, $result->getKey());
-        $this->assertNotSame($taxCategory->getVersion(), $result->getVersion());
-    }
-
-    public function testSetDescription()
-    {
-        $draft = $this->getDraft('set-description');
-        $taxCategory = $this->createTaxCategory($draft);
-
-
-        $description = $this->getTestRun() . '-new-description';
-        $request = TaxCategoryUpdateRequest::ofIdAndVersion(
-            $taxCategory->getId(),
-            $taxCategory->getVersion()
-        )
-            ->addAction(TaxCategorySetDescriptionAction::of()->setDescription($description))
-        ;
-        $response = $request->executeWithClient($this->getClient());
-        $result = $request->mapResponse($response);
-        $this->deleteRequest->setVersion($result->getVersion());
-
-        $this->assertInstanceOf(TaxCategory::class, $result);
-        $this->assertSame($description, $result->getDescription());
-        $this->assertNotSame($taxCategory->getVersion(), $result->getVersion());
-    }
-
-    public function testAddRemoveTaxRate()
-    {
-        $draft = $this->getDraft('add-remove-taxrate');
-        $taxCategory = $this->createTaxCategory($draft);
-
-
-        $taxRate = TaxRate::of()->setName('test-' . $this->getTestRun() . '-rate2')
+        return TaxRate::of()->setName('test-' . $this->getTestRun() . '-rate2')
             ->setAmount(0.3)
             ->setIncludedInPrice(true)
             ->setCountry('DE')
             ->setState('new-' . $this->getRegion());
-        $request = TaxCategoryUpdateRequest::ofIdAndVersion(
-            $taxCategory->getId(),
-            $taxCategory->getVersion()
-        )
-            ->addAction(TaxCategoryAddTaxRateAction::ofTaxRate($taxRate))
-        ;
-        $response = $request->executeWithClient($this->getClient());
-        $result = $request->mapResponse($response);
-        $this->deleteRequest->setVersion($result->getVersion());
+    }
 
-        $this->assertInstanceOf(TaxCategory::class, $result);
-        $this->assertCount(2, $result->getRates());
-        $this->assertNotSame($taxCategory->getVersion(), $result->getVersion());
-        $taxCategory = $result;
+    public function testChangeName()
+    {
+        $client = $this->getApiClient();
 
-        $request = TaxCategoryUpdateRequest::ofIdAndVersion(
-            $taxCategory->getId(),
-            $taxCategory->getVersion()
-        )
-            ->addAction(TaxCategoryRemoveTaxRateAction::ofTaxRateId($result->getRates()->current()->getId()))
-        ;
-        $response = $request->executeWithClient($this->getClient());
-        $result = $request->mapResponse($response);
-        $this->deleteRequest->setVersion($result->getVersion());
+        TaxCategoryFixture::withUpdateableDraftTaxCategory(
+            $client,
+            function (TaxCategoryDraft $draft) {
+                return $draft->setName('change-name');
+            },
+            function (TaxCategory $taxCategory) use ($client) {
+                $name = 'new-name';
+                $request = RequestBuilder::of()->taxCategories()->update($taxCategory)
+                    ->addAction(TaxCategoryChangeNameAction::ofName($name));
+                $response = $this->execute($client, $request);
+                $result = $request->mapFromResponse($response);
 
-        $this->assertInstanceOf(TaxCategory::class, $result);
-        $this->assertCount(1, $result->getRates());
-        $this->assertNotSame($taxCategory->getVersion(), $result->getVersion());
+                $this->assertInstanceOf(TaxCategory::class, $result);
+                $this->assertSame($name, $result->getName());
+                $this->assertNotSame($taxCategory->getVersion(), $result->getVersion());
+
+                return $result;
+            }
+        );
+    }
+
+    public function testUpdateNameByKey()
+    {
+        $client = $this->getApiClient();
+
+        TaxCategoryFixture::withUpdateableDraftTaxCategory(
+            $client,
+            function (TaxCategoryDraft $draft) {
+                return $draft->setName('update name')->setKey('set-key');
+            },
+            function (TaxCategory $taxCategory) use ($client) {
+                $name = 'new-name';
+                $request = RequestBuilder::of()->taxCategories()->update($taxCategory)
+                    ->addAction(TaxCategoryChangeNameAction::ofName($name));
+                $response = $this->execute($client, $request);
+                $result = $request->mapFromResponse($response);
+
+                $this->assertInstanceOf(TaxCategory::class, $result);
+                $this->assertSame($name, $result->getName());
+                $this->assertNotSame($taxCategory->getVersion(), $result->getVersion());
+
+                return $result;
+            }
+        );
+    }
+
+    public function testSetKey()
+    {
+        $client = $this->getApiClient();
+
+        TaxCategoryFixture::withUpdateableDraftTaxCategory(
+            $client,
+            function (TaxCategoryDraft $draft) {
+                return $draft->setKey('set-key');
+            },
+            function (TaxCategory $taxCategory) use ($client) {
+                $key = 'new-key';
+                $request = RequestBuilder::of()->taxCategories()->update($taxCategory)
+                    ->addAction(TaxCategorySetKeyAction::ofKey($key));
+                $response = $this->execute($client, $request);
+                $result = $request->mapFromResponse($response);
+
+                $this->assertInstanceOf(TaxCategory::class, $result);
+                $this->assertNotSame($key, 'set-key');
+                $this->assertSame($key, $result->getKey());
+                $this->assertNotSame($taxCategory->getVersion(), $result->getVersion());
+
+                return $result;
+            }
+        );
+    }
+
+    public function testSetDescription()
+    {
+        $client = $this->getApiClient();
+
+        TaxCategoryFixture::withUpdateableDraftTaxCategory(
+            $client,
+            function (TaxCategoryDraft $draft) {
+                return $draft->setDescription('set-description');
+            },
+            function (TaxCategory $taxCategory) use ($client) {
+                $description = 'new-description';
+                $request = RequestBuilder::of()->taxCategories()->update($taxCategory)
+                    ->addAction(TaxCategorySetDescriptionAction::of()->setDescription($description));
+                $response = $this->execute($client, $request);
+                $result = $request->mapFromResponse($response);
+
+                $this->assertInstanceOf(TaxCategory::class, $result);
+                $this->assertSame($description, $result->getDescription());
+                $this->assertNotSame($taxCategory->getVersion(), $result->getVersion());
+
+                return $result;
+            }
+        );
+    }
+
+    public function testAddRemoveTaxRate()
+    {
+        $client = $this->getApiClient();
+
+        TaxCategoryFixture::withUpdateableTaxCategory(
+            $client,
+            function (TaxCategory $taxCategory) use ($client) {
+                $taxRate = $this->getTaxRate();
+                $request = RequestBuilder::of()->taxCategories()->update($taxCategory)
+                    ->addAction(TaxCategoryAddTaxRateAction::ofTaxRate($taxRate));
+                $response = $this->execute($client, $request);
+                $result = $request->mapFromResponse($response);
+
+                $this->assertInstanceOf(TaxCategory::class, $result);
+                $this->assertCount(2, $result->getRates());
+                $this->assertNotSame($taxCategory->getVersion(), $result->getVersion());
+
+                $taxCategory = $result;
+                $request = RequestBuilder::of()->taxCategories()->update($result)
+                    ->addAction(TaxCategoryRemoveTaxRateAction::ofTaxRateId($result->getRates()->current()->getId()));
+                $response = $this->execute($client, $request);
+                $result = $request->mapFromResponse($response);
+
+                $this->assertInstanceOf(TaxCategory::class, $result);
+                $this->assertCount(1, $result->getRates());
+                $this->assertNotSame($taxCategory->getVersion(), $result->getVersion());
+
+                return $result;
+            }
+        );
     }
 
     public function testReplaceTaxRate()
     {
-        $draft = $this->getDraft('add-remove-taxrate');
-        $taxCategory = $this->createTaxCategory($draft);
+        $client = $this->getApiClient();
 
+        TaxCategoryFixture::withUpdateableTaxCategory(
+            $client,
+            function (TaxCategory $taxCategory) use ($client) {
+                $taxRate = $this->getTaxRate();
+                $request = RequestBuilder::of()->taxCategories()->update($taxCategory)
+                    ->addAction(TaxCategoryReplaceTaxRateAction::ofTaxRateIdAndTaxRate(
+                        $taxCategory->getRates()->current()->getId(),
+                        $taxRate
+                    ));
+                $response = $this->execute($client, $request);
+                $result = $request->mapFromResponse($response);
 
-        $taxRate = TaxRate::of()->setName('test-' . $this->getTestRun() . '-rate2')
-            ->setAmount(0.3)
-            ->setIncludedInPrice(true)
-            ->setCountry('DE')
-            ->setState($this->getRegion());
-        $request = TaxCategoryUpdateRequest::ofIdAndVersion(
-            $taxCategory->getId(),
-            $taxCategory->getVersion()
-        )
-            ->addAction(TaxCategoryReplaceTaxRateAction::ofTaxRateIdAndTaxRate(
-                $taxCategory->getRates()->current()->getId(),
-                $taxRate
-            ))
-        ;
-        $response = $request->executeWithClient($this->getClient());
-        $result = $request->mapResponse($response);
-        $this->deleteRequest->setVersion($result->getVersion());
+                $this->assertInstanceOf(TaxCategory::class, $result);
+                $this->assertSame($taxRate->getName(), $result->getRates()->current()->getName());
+                $this->assertNotSame($taxCategory->getVersion(), $result->getVersion());
 
-        $this->assertInstanceOf(TaxCategory::class, $result);
-        $this->assertSame($taxRate->getName(), $result->getRates()->current()->getName());
-        $this->assertNotSame($taxCategory->getVersion(), $result->getVersion());
+                return $result;
+            }
+        );
     }
 }

--- a/tests/integration/Type/TypeFixture.php
+++ b/tests/integration/Type/TypeFixture.php
@@ -1,0 +1,156 @@
+<?php
+
+namespace Commercetools\Core\IntegrationTests\Type;
+
+use Commercetools\Core\Client\ApiClient;
+use Commercetools\Core\Helper\Uuid;
+use Commercetools\Core\IntegrationTests\ResourceFixture;
+use Commercetools\Core\Model\Common\LocalizedString;
+use Commercetools\Core\Model\Type\FieldDefinition;
+use Commercetools\Core\Model\Type\FieldDefinitionCollection;
+use Commercetools\Core\Model\Type\StringType;
+use Commercetools\Core\Model\Type\Type;
+use Commercetools\Core\Model\Type\TypeDraft;
+use Commercetools\Core\Request\Types\TypeCreateRequest;
+use Commercetools\Core\Request\Types\TypeDeleteRequest;
+
+class TypeFixture extends ResourceFixture
+{
+    const CREATE_REQUEST_TYPE = TypeCreateRequest::class;
+    const DELETE_REQUEST_TYPE = TypeDeleteRequest::class;
+
+    final public static function uniqueTypeString()
+    {
+        return 'test-' . Uuid::uuidv4();
+    }
+
+    final public static function defaultTypeDraftFunction()
+    {
+        $uniqueTypeString = self::uniqueTypeString();
+
+        $draft = TypeDraft::ofKeyNameDescriptionAndResourceTypes(
+            'key-' . $uniqueTypeString,
+            LocalizedString::ofLangAndText('en', 'test-' . $uniqueTypeString . '-name'),
+            LocalizedString::ofLangAndText('en', 'test-' . $uniqueTypeString . '-description'),
+            ['category']
+        );
+        $draft->setFieldDefinitions(
+            FieldDefinitionCollection::of()
+            ->add(
+                FieldDefinition::of()
+                    ->setName('testField')
+                    ->setLabel(LocalizedString::ofLangAndText('en', 'testField'))
+                    ->setRequired(false)
+                    ->setInputHint('SingleLine')
+                    ->setType(StringType::of())
+            )
+        );
+
+        return $draft;
+    }
+
+    final public static function defaultTypeDraftBuilderFunction(TypeDraft $draft)
+    {
+        return $draft;
+    }
+
+    final public static function defaultTypeCreateFunction(ApiClient $client, TypeDraft $draft)
+    {
+        return parent::defaultCreateFunction($client, self::CREATE_REQUEST_TYPE, $draft);
+    }
+
+    final public static function defaultTypeDeleteFunction(ApiClient $client, Type $resource)
+    {
+        return parent::defaultDeleteFunction($client, self::DELETE_REQUEST_TYPE, $resource);
+    }
+
+    final public static function withUpdateableDraftType(
+        ApiClient $client,
+        callable $draftBuilderFunction,
+        callable $assertFunction,
+        callable $createFunction = null,
+        callable $deleteFunction = null,
+        callable $draftFunction = null
+    ) {
+        if ($draftFunction == null) {
+            $draftFunction = [__CLASS__, 'defaultTypeDraftFunction'];
+        }
+        if ($createFunction == null) {
+            $createFunction = [__CLASS__, 'defaultTypeCreateFunction'];
+        }
+        if ($deleteFunction == null) {
+            $deleteFunction = [__CLASS__, 'defaultTypeDeleteFunction'];
+        }
+
+        parent::withUpdateableDraftResource(
+            $client,
+            $draftBuilderFunction,
+            $assertFunction,
+            $createFunction,
+            $deleteFunction,
+            $draftFunction
+        );
+    }
+
+    final public static function withDraftType(
+        ApiClient $client,
+        callable $draftBuilderFunction,
+        callable $assertFunction,
+        callable $createFunction = null,
+        callable $deleteFunction = null,
+        callable $draftFunction = null
+    ) {
+        if ($draftFunction == null) {
+            $draftFunction = [__CLASS__, 'defaultTypeDraftFunction'];
+        }
+        if ($createFunction == null) {
+            $createFunction = [__CLASS__, 'defaultTypeCreateFunction'];
+        }
+        if ($deleteFunction == null) {
+            $deleteFunction = [__CLASS__, 'defaultTypeDeleteFunction'];
+        }
+
+        parent::withDraftResource(
+            $client,
+            $draftBuilderFunction,
+            $assertFunction,
+            $createFunction,
+            $deleteFunction,
+            $draftFunction
+        );
+    }
+
+    final public static function withType(
+        ApiClient $client,
+        callable $assertFunction,
+        callable $createFunction = null,
+        callable $deleteFunction = null,
+        callable $draftFunction = null
+    ) {
+        self::withDraftType(
+            $client,
+            [__CLASS__, 'defaultTypeDraftBuilderFunction'],
+            $assertFunction,
+            $createFunction,
+            $deleteFunction,
+            $draftFunction
+        );
+    }
+
+    final public static function withUpdateableType(
+        ApiClient $client,
+        callable $assertFunction,
+        callable $createFunction = null,
+        callable $deleteFunction = null,
+        callable $draftFunction = null
+    ) {
+        self::withUpdateableDraftType(
+            $client,
+            [__CLASS__, 'defaultTypeDraftBuilderFunction'],
+            $assertFunction,
+            $createFunction,
+            $deleteFunction,
+            $draftFunction
+        );
+    }
+}

--- a/tests/integration/Zone/ZoneFixture.php
+++ b/tests/integration/Zone/ZoneFixture.php
@@ -1,0 +1,145 @@
+<?php
+
+namespace Commercetools\Core\IntegrationTests\Zone;
+
+use Commercetools\Core\Client\ApiClient;
+use Commercetools\Core\Helper\Uuid;
+use Commercetools\Core\IntegrationTests\ResourceFixture;
+use Commercetools\Core\Model\Zone\Location;
+use Commercetools\Core\Model\Zone\LocationCollection;
+use Commercetools\Core\Model\Zone\Zone;
+use Commercetools\Core\Model\Zone\ZoneDraft;
+use Commercetools\Core\Request\Zones\ZoneCreateRequest;
+use Commercetools\Core\Request\Zones\ZoneDeleteRequest;
+
+class ZoneFixture extends ResourceFixture
+{
+    const CREATE_REQUEST_TYPE = ZoneCreateRequest::class;
+    const DELETE_REQUEST_TYPE = ZoneDeleteRequest::class;
+    const RAND_MAX = 10000;
+
+    final public static function uniqueZoneString()
+    {
+        return 'test-' . Uuid::uuidv4();
+    }
+
+    final public static function defaultZoneDraftFunction()
+    {
+        $uniqueZoneString = self::uniqueZoneString();
+        $region = "r" . (string)mt_rand(1, static::RAND_MAX);
+
+        $draft = ZoneDraft::ofNameAndLocations(
+            'test-' . $uniqueZoneString . '-name',
+            LocationCollection::of()->add(
+                Location::of()->setCountry('DE')->setState($region)
+            )
+        )->setKey($uniqueZoneString);
+
+        return $draft;
+    }
+
+    final public static function defaultZoneDraftBuilderFunction(ZoneDraft $draft)
+    {
+        return $draft;
+    }
+
+    final public static function defaultZoneCreateFunction(ApiClient $client, ZoneDraft $draft)
+    {
+        return parent::defaultCreateFunction($client, self::CREATE_REQUEST_TYPE, $draft);
+    }
+
+    final public static function defaultZoneDeleteFunction(ApiClient $client, Zone $resource)
+    {
+        return parent::defaultDeleteFunction($client, self::DELETE_REQUEST_TYPE, $resource);
+    }
+
+    final public static function withUpdateableDraftZone(
+        ApiClient $client,
+        callable $draftBuilderFunction,
+        callable $assertFunction,
+        callable $createFunction = null,
+        callable $deleteFunction = null,
+        callable $draftFunction = null
+    ) {
+        if ($draftFunction == null) {
+            $draftFunction = [__CLASS__, 'defaultZoneDraftFunction'];
+        }
+        if ($createFunction == null) {
+            $createFunction = [__CLASS__, 'defaultZoneCreateFunction'];
+        }
+        if ($deleteFunction == null) {
+            $deleteFunction = [__CLASS__, 'defaultZoneDeleteFunction'];
+        }
+
+        parent::withUpdateableDraftResource(
+            $client,
+            $draftBuilderFunction,
+            $assertFunction,
+            $createFunction,
+            $deleteFunction,
+            $draftFunction
+        );
+    }
+
+    final public static function withDraftZone(
+        ApiClient $client,
+        callable $draftBuilderFunction,
+        callable $assertFunction,
+        callable $createFunction = null,
+        callable $deleteFunction = null,
+        callable $draftFunction = null
+    ) {
+        if ($draftFunction == null) {
+            $draftFunction = [__CLASS__, 'defaultZoneDraftFunction'];
+        }
+        if ($createFunction == null) {
+            $createFunction = [__CLASS__, 'defaultZoneCreateFunction'];
+        }
+        if ($deleteFunction == null) {
+            $deleteFunction = [__CLASS__, 'defaultZoneDeleteFunction'];
+        }
+
+        parent::withDraftResource(
+            $client,
+            $draftBuilderFunction,
+            $assertFunction,
+            $createFunction,
+            $deleteFunction,
+            $draftFunction
+        );
+    }
+
+    final public static function withZone(
+        ApiClient $client,
+        callable $assertFunction,
+        callable $createFunction = null,
+        callable $deleteFunction = null,
+        callable $draftFunction = null
+    ) {
+        self::withDraftZone(
+            $client,
+            [__CLASS__, 'defaultZoneDraftBuilderFunction'],
+            $assertFunction,
+            $createFunction,
+            $deleteFunction,
+            $draftFunction
+        );
+    }
+
+    final public static function withUpdateableZone(
+        ApiClient $client,
+        callable $assertFunction,
+        callable $createFunction = null,
+        callable $deleteFunction = null,
+        callable $draftFunction = null
+    ) {
+        self::withUpdateableDraftZone(
+            $client,
+            [__CLASS__, 'defaultZoneDraftBuilderFunction'],
+            $assertFunction,
+            $createFunction,
+            $deleteFunction,
+            $draftFunction
+        );
+    }
+}

--- a/tests/integration/Zone/ZoneQueryRequestTest.php
+++ b/tests/integration/Zone/ZoneQueryRequestTest.php
@@ -3,104 +3,81 @@
  * @author @jenschude <jens.schulze@commercetools.de>
  */
 
-
 namespace Commercetools\Core\IntegrationTests\Zone;
 
+use Commercetools\Core\Builder\Request\RequestBuilder;
 use Commercetools\Core\IntegrationTests\ApiTestCase;
 use Commercetools\Core\Model\Zone\Zone;
-use Commercetools\Core\Model\Zone\ZoneDraft;
-use Commercetools\Core\Model\Zone\Location;
-use Commercetools\Core\Model\Zone\LocationCollection;
-use Commercetools\Core\Request\Zones\ZoneByIdGetRequest;
-use Commercetools\Core\Request\Zones\ZoneByKeyGetRequest;
-use Commercetools\Core\Request\Zones\ZoneCreateRequest;
-use Commercetools\Core\Request\Zones\ZoneDeleteByKeyRequest;
-use Commercetools\Core\Request\Zones\ZoneDeleteRequest;
-use Commercetools\Core\Request\Zones\ZoneQueryRequest;
 
 class ZoneQueryRequestTest extends ApiTestCase
 {
-    /**
-     * @return ZoneDraft
-     */
-    protected function getDraft()
-    {
-        $draft = ZoneDraft::ofNameAndLocations(
-            'test-' . $this->getTestRun() . '-name',
-            LocationCollection::of()->add(
-                Location::of()->setCountry('DE')->setState($this->getRegion())
-            )
-        );
-
-        return $draft;
-    }
-
-    protected function createZone(ZoneDraft $draft)
-    {
-        $request = ZoneCreateRequest::ofDraft($draft);
-        $response = $request->executeWithClient($this->getClient());
-        $zone = $request->mapResponse($response);
-
-        $this->cleanupRequests[] = ZoneDeleteRequest::ofIdAndVersion(
-            $zone->getId(),
-            $zone->getVersion()
-        );
-
-        return $zone;
-    }
-
     public function testQuery()
     {
-        $draft = $this->getDraft();
-        $zone = $this->createZone($draft);
+        $client = $this->getApiClient();
 
-        $request = ZoneQueryRequest::of()->where('name="' . $draft->getName() . '"');
-        $response = $request->executeWithClient($this->getClient());
-        $result = $request->mapResponse($response);
+        ZoneFixture::withZone(
+            $client,
+            function (Zone $zone) use ($client) {
+                $request = RequestBuilder::of()->zones()->query()
+                    ->where('name=:name', ['name' => $zone->getName()]);
+                $response = $this->execute($client, $request);
+                $result = $request->mapFromResponse($response);
 
-        $this->assertCount(1, $result);
-        $this->assertInstanceOf(Zone::class, $result->getAt(0));
-        $this->assertSame($zone->getId(), $result->getAt(0)->getId());
+                $this->assertCount(1, $result);
+                $this->assertInstanceOf(Zone::class, $result->current());
+                $this->assertSame($zone->getId(), $result->current()->getId());
+            }
+        );
     }
 
     public function testGetById()
     {
-        $draft = $this->getDraft();
-        $zone = $this->createZone($draft);
+        $client = $this->getApiClient();
 
-        $request = ZoneByIdGetRequest::ofId($zone->getId());
-        $response = $request->executeWithClient($this->getClient());
-        $result = $request->mapResponse($response);
+        ZoneFixture::withZone(
+            $client,
+            function (Zone $zone) use ($client) {
+                $request = RequestBuilder::of()->zones()->getById($zone->getId());
+                $response = $this->execute($client, $request);
+                $result = $request->mapFromResponse($response);
 
-        $this->assertInstanceOf(Zone::class, $zone);
-        $this->assertSame($zone->getId(), $result->getId());
+                $this->assertInstanceOf(Zone::class, $zone);
+                $this->assertSame($zone->getId(), $result->getId());
+            }
+        );
     }
 
     public function testGetByKey()
     {
-        $draft = $this->getDraft()->setKey('key-' . $this->getTestRun());
-        $zone = $this->createZone($draft);
+        $client = $this->getApiClient();
 
-        $request = ZoneByKeyGetRequest::ofKey($zone->getKey());
-        $response = $request->executeWithClient($this->getClient());
-        $result = $request->mapResponse($response);
+        ZoneFixture::withZone(
+            $client,
+            function (Zone $zone) use ($client) {
+                $request = RequestBuilder::of()->zones()->getByKey($zone->getKey());
+                $response = $this->execute($client, $request);
+                $result = $request->mapFromResponse($response);
 
-        $this->assertInstanceOf(Zone::class, $zone);
-        $this->assertSame($zone->getKey(), $result->getKey());
+                $this->assertInstanceOf(Zone::class, $zone);
+                $this->assertSame($zone->getId(), $result->getId());
+                $this->assertSame($zone->getKey(), $result->getKey());
+            }
+        );
     }
-
+    //TODO for Consistancy: should I change the place of this test? in other part it's in createRequestTest or in Update
     public function testDeleteByKey()
     {
-        $draft = $this->getDraft()->setKey('key-' . $this->getTestRun());
-        $zone = $this->createZone($draft);
+        $client = $this->getApiClient();
 
-        $request = ZoneDeleteByKeyRequest::ofKeyAndVersion(
-            $zone->getKey(),
-            $zone->getVersion()
+        ZoneFixture::withZone(
+            $client,
+            function (Zone $zone) use ($client) {
+                $request = RequestBuilder::of()->zones()->deleteByKey($zone);
+                $response = $this->execute($client, $request);
+                $result = $request->mapFromResponse($response);
+
+                $this->assertSame($zone->getId(), $result->getId());
+            }
         );
-        $result = $this->getClient()->execute($request);
-        $response = $request->mapFromResponse($result);
-
-        $this->assertSame($zone->getId(), $response->getId());
     }
 }

--- a/tests/integration/Zone/ZoneUpdateRequestTest.php
+++ b/tests/integration/Zone/ZoneUpdateRequestTest.php
@@ -3,12 +3,11 @@
  * @author @jenschude <jens.schulze@commercetools.de>
  */
 
-
 namespace Commercetools\Core\IntegrationTests\Zone;
 
+use Commercetools\Core\Builder\Request\RequestBuilder;
 use Commercetools\Core\IntegrationTests\ApiTestCase;
 use Commercetools\Core\Model\Zone\Location;
-use Commercetools\Core\Model\Zone\LocationCollection;
 use Commercetools\Core\Model\Zone\Zone;
 use Commercetools\Core\Model\Zone\ZoneDraft;
 use Commercetools\Core\Request\Zones\Command\ZoneAddLocationAction;
@@ -16,140 +15,109 @@ use Commercetools\Core\Request\Zones\Command\ZoneChangeNameAction;
 use Commercetools\Core\Request\Zones\Command\ZoneRemoveLocationAction;
 use Commercetools\Core\Request\Zones\Command\ZoneSetDescriptionAction;
 use Commercetools\Core\Request\Zones\Command\ZoneSetKeyAction;
-use Commercetools\Core\Request\Zones\ZoneCreateRequest;
-use Commercetools\Core\Request\Zones\ZoneDeleteRequest;
-use Commercetools\Core\Request\Zones\ZoneUpdateByKeyRequest;
-use Commercetools\Core\Request\Zones\ZoneUpdateRequest;
 
 class ZoneUpdateRequestTest extends ApiTestCase
 {
-    /**
-     * @return ZoneDraft
-     */
-    protected function getDraft($name)
-    {
-        $draft = ZoneDraft::ofNameAndLocations(
-            'test-' . $this->getTestRun() . '-' . $name,
-            LocationCollection::of()->add(
-                Location::of()->setCountry('DE')->setState($this->getRegion())
-            )
-        );
-
-        return $draft;
-    }
-
-    protected function createZone(ZoneDraft $draft)
-    {
-        $request = ZoneCreateRequest::ofDraft($draft);
-        $response = $request->executeWithClient($this->getClient());
-        $zone = $request->mapResponse($response);
-
-        $this->cleanupRequests[] = $this->deleteRequest = ZoneDeleteRequest::ofIdAndVersion(
-            $zone->getId(),
-            $zone->getVersion()
-        );
-
-        return $zone;
-    }
-
     public function testSetDescription()
     {
-        $draft = $this->getDraft('set-description');
-        $zone = $this->createZone($draft);
+        $client = $this->getApiClient();
 
+        ZoneFixture::withUpdateableDraftZone(
+            $client,
+            function (ZoneDraft $draft) {
+                return $draft->setDescription('set-description');
+            },
+            function (Zone $zone) use ($client) {
+                $description = 'new-description';
+                $request = RequestBuilder::of()->zones()->update($zone)
+                    ->addAction(ZoneSetDescriptionAction::of()->setDescription($description));
+                $response = $this->execute($client, $request);
+                $result = $request->mapFromResponse($response);
 
-        $description = $this->getTestRun() . '-new-description';
-        $request = ZoneUpdateRequest::ofIdAndVersion(
-            $zone->getId(),
-            $zone->getVersion()
-        )
-            ->addAction(ZoneSetDescriptionAction::of()->setDescription($description))
-        ;
-        $response = $request->executeWithClient($this->getClient());
-        $result = $request->mapResponse($response);
-        $this->deleteRequest->setVersion($result->getVersion());
+                $this->assertInstanceOf(Zone::class, $result);
+                $this->assertSame($description, $result->getDescription());
+                $this->assertNotSame($zone->getVersion(), $result->getVersion());
 
-        $this->assertInstanceOf(Zone::class, $result);
-        $this->assertSame($description, $result->getDescription());
-        $this->assertNotSame($zone->getVersion(), $result->getVersion());
+                return $result;
+            }
+        );
     }
 
     public function testChangeName()
     {
-        $draft = $this->getDraft('change-name');
-        $zone = $this->createZone($draft);
+        $client = $this->getApiClient();
 
+        ZoneFixture::withUpdateableDraftZone(
+            $client,
+            function (ZoneDraft $draft) {
+                return $draft->setName('change-name');
+            },
+            function (Zone $zone) use ($client) {
+                $name = 'new-name';
+                $request = RequestBuilder::of()->zones()->update($zone)
+                    ->addAction(ZoneChangeNameAction::ofName($name));
+                $response = $this->execute($client, $request);
+                $result = $request->mapFromResponse($response);
 
-        $name = $this->getTestRun() . '-new-name';
-        $request = ZoneUpdateRequest::ofIdAndVersion(
-            $zone->getId(),
-            $zone->getVersion()
-        )
-            ->addAction(ZoneChangeNameAction::ofName($name))
-        ;
-        $response = $request->executeWithClient($this->getClient());
-        $result = $request->mapResponse($response);
-        $this->deleteRequest->setVersion($result->getVersion());
+                $this->assertInstanceOf(Zone::class, $result);
+                $this->assertSame($name, $result->getName());
+                $this->assertNotSame($zone->getVersion(), $result->getVersion());
 
-        $this->assertInstanceOf(Zone::class, $result);
-        $this->assertSame($name, $result->getName());
-        $this->assertNotSame($zone->getVersion(), $result->getVersion());
+                return $result;
+            }
+        );
     }
 
     public function testAddRemoveLocation()
     {
-        $draft = $this->getDraft('add-location');
-        $zone = $this->createZone($draft);
+        $client = $this->getApiClient();
 
-        $location = Location::of()->setCountry('DE')->setState('new-' . $this->getRegion());
-        $request = ZoneUpdateRequest::ofIdAndVersion(
-            $zone->getId(),
-            $zone->getVersion()
-        )
-            ->addAction(ZoneAddLocationAction::ofLocation($location))
-        ;
-        $response = $request->executeWithClient($this->getClient());
-        $result = $request->mapResponse($response);
-        $this->deleteRequest->setVersion($result->getVersion());
+        ZoneFixture::withUpdateableZone(
+            $client,
+            function (Zone $zone) use ($client) {
+                $location = Location::of()->setCountry('DE')->setState('new-' . $this->getRegion());
+                $request = RequestBuilder::of()->zones()->update($zone)
+                    ->addAction(ZoneAddLocationAction::ofLocation($location));
+                $response = $this->execute($client, $request);
+                $result = $request->mapFromResponse($response);
 
-        $this->assertInstanceOf(Zone::class, $result);
-        $this->assertCount(2, $result->getLocations());
-        $this->assertNotSame($zone->getVersion(), $result->getVersion());
-        $zone = $result;
+                $this->assertInstanceOf(Zone::class, $result);
+                $this->assertCount(2, $result->getLocations());
+                $this->assertNotSame($zone->getVersion(), $result->getVersion());
 
-        $request = ZoneUpdateRequest::ofIdAndVersion(
-            $zone->getId(),
-            $zone->getVersion()
-        )
-            ->addAction(ZoneRemoveLocationAction::ofLocation($location))
-        ;
-        $response = $request->executeWithClient($this->getClient());
-        $result = $request->mapResponse($response);
-        $this->deleteRequest->setVersion($result->getVersion());
+                $request = RequestBuilder::of()->zones()->update($result)
+                    ->addAction(ZoneRemoveLocationAction::ofLocation($location));
+                $response = $this->execute($client, $request);
+                $result = $request->mapFromResponse($response);
 
-        $this->assertInstanceOf(Zone::class, $result);
-        $this->assertCount(1, $result->getLocations());
-        $this->assertNotSame($zone->getVersion(), $result->getVersion());
+                $this->assertInstanceOf(Zone::class, $result);
+                $this->assertCount(1, $result->getLocations());
+                $this->assertNotSame($zone->getVersion(), $result->getVersion());
+
+                return $result;
+            }
+        );
     }
 
     public function testUpdateByKey()
     {
-        $draft = $this->getDraft('change-key')->setKey($this->getTestRun() . '-key');
-        $zone = $this->createZone($draft);
+        $client = $this->getApiClient();
 
-        $key = $this->getTestRun() . '-new-key';
-        $request = ZoneUpdateByKeyRequest::ofKeyAndVersion(
-            $zone->getKey(),
-            $zone->getVersion()
-        )
-            ->addAction(ZoneSetKeyAction::ofKey($key))
-        ;
-        $response = $request->executeWithClient($this->getClient());
-        $result = $request->mapResponse($response);
-        $this->deleteRequest->setVersion($result->getVersion());
+        ZoneFixture::withUpdateableZone(
+            $client,
+            function (Zone $zone) use ($client) {
+                $key = 'new-key';
+                $request = RequestBuilder::of()->zones()->update($zone)
+                    ->addAction(ZoneSetKeyAction::ofKey($key));
+                $response = $this->execute($client, $request);
+                $result = $request->mapFromResponse($response);
 
-        $this->assertInstanceOf(Zone::class, $result);
-        $this->assertSame($key, $result->getKey());
-        $this->assertNotSame($zone->getVersion(), $result->getVersion());
+                $this->assertInstanceOf(Zone::class, $result);
+                $this->assertSame($key, $result->getKey());
+                $this->assertNotSame($zone->getVersion(), $result->getVersion());
+
+                return $result;
+            }
+        );
     }
 }


### PR DESCRIPTION
not sure if it has to be done or not. Right now these tests are skipped and it has to be changed the logic behind the method Destination::ofUri. To check with @jenschude 

1. code and add tests that cover the created code. Your code should be warning-free.
   * [ ] tests existing
1. stick to PSR-2 and and don't reformat existing code.
   * [ ] code style check successful