### PR TITLE
Subscription integration test refactor not sure

### DIFF
--- a/tests/integration/Subscription/SubscriptionDeleteRequestTest.php
+++ b/tests/integration/Subscription/SubscriptionDeleteRequestTest.php
@@ -5,14 +5,9 @@
 
 namespace Commercetools\Core\IntegrationTests\Subscription;
 
+use Commercetools\Core\Builder\Request\RequestBuilder;
 use Commercetools\Core\IntegrationTests\ApiTestCase;
-use Commercetools\Core\Model\Subscription\IronMQDestination;
-use Commercetools\Core\Model\Subscription\MessageSubscription;
-use Commercetools\Core\Model\Subscription\MessageSubscriptionCollection;
-use Commercetools\Core\Model\Subscription\SubscriptionDraft;
-use Commercetools\Core\Request\Subscriptions\SubscriptionCreateRequest;
-use Commercetools\Core\Request\Subscriptions\SubscriptionDeleteByKeyRequest;
-use Commercetools\Core\Request\Subscriptions\SubscriptionDeleteRequest;
+use Commercetools\Core\Model\Subscription\Subscription;
 
 class SubscriptionDeleteRequestTest extends ApiTestCase
 {
@@ -23,15 +18,18 @@ class SubscriptionDeleteRequestTest extends ApiTestCase
             $this->markTestSkipped('Message Queue URL not configured');
         }
     }
+
     public function testDeleteById()
     {
         $client = $this->getApiClient();
+
         SubscriptionFixture::withSubscription(
             $client,
             function (Subscription $subscription) use ($client) {
                 $request = RequestBuilder::of()->subscriptions()->delete($subscription);
                 $response = $client->execute($request);
                 $result = $request->mapFromResponse($response);
+
                 $this->assertSame($subscription->getId(), $result->getId());
             }
         );
@@ -39,12 +37,14 @@ class SubscriptionDeleteRequestTest extends ApiTestCase
     public function testDeleteByKey()
     {
         $client = $this->getApiClient();
+
         SubscriptionFixture::withSubscription(
             $client,
             function (Subscription $subscription) use ($client) {
                 $request = RequestBuilder::of()->subscriptions()->deleteByKey($subscription);
                 $response = $client->execute($request);
                 $result = $request->mapFromResponse($response);
+
                 $this->assertSame($subscription->getId(), $result->getId());
             }
         );

--- a/tests/integration/Subscription/SubscriptionDeleteRequestTest.php
+++ b/tests/integration/Subscription/SubscriptionDeleteRequestTest.php
@@ -23,57 +23,30 @@ class SubscriptionDeleteRequestTest extends ApiTestCase
             $this->markTestSkipped('Message Queue URL not configured');
         }
     }
-
-    /**
-     * @return SubscriptionDraft
-     */
-    protected function getDraft()
-    {
-        $uri = getenv('IRONMQ_URI');
-        $destination = IronMQDestination::ofUri($uri);
-        $messages = MessageSubscriptionCollection::of()->add(MessageSubscription::of()->setResourceTypeId('product'));
-        $key = 'test-' . $this->getTestRun();
-        $draft = SubscriptionDraft::ofKeyDestinationAndMessages($key, $destination, $messages);
-
-        return $draft;
-    }
-
-    protected function createSubscription(SubscriptionDraft $draft)
-    {
-        $request = SubscriptionCreateRequest::ofDraft($draft);
-        $response = $request->executeWithClient($this->getClient());
-        $subscription = $request->mapResponse($response);
-        $this->cleanupRequests[] = $this->deleteRequest = SubscriptionDeleteRequest::ofIdAndVersion(
-            $subscription->getId(),
-            $subscription->getVersion()
-        );
-
-        return $subscription;
-    }
-
     public function testDeleteById()
     {
-        $draft = $this->getDraft();
-        $subscription = $this->createSubscription($draft);
-
-        $request = SubscriptionDeleteRequest::ofIdAndVersion(
-            $subscription->getId(),
-            $subscription->getVersion()
+        $client = $this->getApiClient();
+        SubscriptionFixture::withSubscription(
+            $client,
+            function (Subscription $subscription) use ($client) {
+                $request = RequestBuilder::of()->subscriptions()->delete($subscription);
+                $response = $client->execute($request);
+                $result = $request->mapFromResponse($response);
+                $this->assertSame($subscription->getId(), $result->getId());
+            }
         );
-        $response = $request->executeWithClient($this->getClient());
-        $this->assertFalse($response->isError());
     }
-
     public function testDeleteByKey()
     {
-        $draft = $this->getDraft();
-        $subscription = $this->createSubscription($draft);
-
-        $request = SubscriptionDeleteByKeyRequest::ofKeyAndVersion(
-            $subscription->getKey(),
-            $subscription->getVersion()
+        $client = $this->getApiClient();
+        SubscriptionFixture::withSubscription(
+            $client,
+            function (Subscription $subscription) use ($client) {
+                $request = RequestBuilder::of()->subscriptions()->deleteByKey($subscription);
+                $response = $client->execute($request);
+                $result = $request->mapFromResponse($response);
+                $this->assertSame($subscription->getId(), $result->getId());
+            }
         );
-        $response = $request->executeWithClient($this->getClient());
-        $this->assertFalse($response->isError());
     }
 }

--- a/tests/integration/Subscription/SubscriptionFixture.php
+++ b/tests/integration/Subscription/SubscriptionFixture.php
@@ -17,32 +17,40 @@ class SubscriptionFixture extends ResourceFixture
 {
     const CREATE_REQUEST_TYPE = SubscriptionCreateRequest::class;
     const DELETE_REQUEST_TYPE = SubscriptionDeleteRequest::class;
+
     final public static function uniqueSubscriptionString()
     {
         return 'test-' . Uuid::uuidv4();
     }
+
     final public static function defaultSubscriptionDraftFunction()
     {
         $uniqueSubscriptionString = self::uniqueSubscriptionString();
         $uri = getenv('IRONMQ_URI');
         $destination = Destination::ofUri($uri);
-        $messages = MessageSubscriptionCollection::of()->add(MessageSubscription::of()->setResourceTypeId('product'));
+        $messages = MessageSubscriptionCollection::of()
+            ->add(MessageSubscription::of()->setResourceTypeId('product'));
         $key = 'test-' . $uniqueSubscriptionString;
         $draft = SubscriptionDraft::ofKeyDestinationAndMessages($key, $destination, $messages);
+
         return $draft;
     }
+
     final public static function defaultSubscriptionDraftBuilderFunction(SubscriptionDraft $draft)
     {
         return $draft;
     }
+
     final public static function defaultSubscriptionCreateFunction(ApiClient $client, SubscriptionDraft $draft)
     {
         return parent::defaultCreateFunction($client, self::CREATE_REQUEST_TYPE, $draft);
     }
+
     final public static function defaultSubscriptionDeleteFunction(ApiClient $client, Subscription $resource)
     {
         return parent::defaultDeleteFunction($client, self::DELETE_REQUEST_TYPE, $resource);
     }
+
     final public static function withUpdateableDraftSubscription(
         ApiClient $client,
         callable $draftBuilderFunction,
@@ -60,6 +68,7 @@ class SubscriptionFixture extends ResourceFixture
         if ($deleteFunction == null) {
             $deleteFunction = [__CLASS__, 'defaultSubscriptionDeleteFunction'];
         }
+
         parent::withUpdateableDraftResource(
             $client,
             $draftBuilderFunction,
@@ -69,6 +78,7 @@ class SubscriptionFixture extends ResourceFixture
             $draftFunction
         );
     }
+
     final public static function withDraftSubscription(
         ApiClient $client,
         callable $draftBuilderFunction,
@@ -86,6 +96,7 @@ class SubscriptionFixture extends ResourceFixture
         if ($deleteFunction == null) {
             $deleteFunction = [__CLASS__, 'defaultSubscriptionDeleteFunction'];
         }
+
         parent::withDraftResource(
             $client,
             $draftBuilderFunction,
@@ -95,6 +106,7 @@ class SubscriptionFixture extends ResourceFixture
             $draftFunction
         );
     }
+
     final public static function withSubscription(
         ApiClient $client,
         callable $assertFunction,
@@ -111,6 +123,7 @@ class SubscriptionFixture extends ResourceFixture
             $draftFunction
         );
     }
+    
     final public static function withUpdateableSubscription(
         ApiClient $client,
         callable $assertFunction,

--- a/tests/integration/Subscription/SubscriptionFixture.php
+++ b/tests/integration/Subscription/SubscriptionFixture.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace Commercetools\Core\IntegrationTests\Subscription;
+
+use Commercetools\Core\Client\ApiClient;
+use Commercetools\Core\Helper\Uuid;
+use Commercetools\Core\IntegrationTests\ResourceFixture;
+use Commercetools\Core\Model\Subscription\Destination;
+use Commercetools\Core\Model\Subscription\MessageSubscription;
+use Commercetools\Core\Model\Subscription\MessageSubscriptionCollection;
+use Commercetools\Core\Model\Subscription\Subscription;
+use Commercetools\Core\Model\Subscription\SubscriptionDraft;
+use Commercetools\Core\Request\Subscriptions\SubscriptionCreateRequest;
+use Commercetools\Core\Request\Subscriptions\SubscriptionDeleteRequest;
+
+class SubscriptionFixture extends ResourceFixture
+{
+    const CREATE_REQUEST_TYPE = SubscriptionCreateRequest::class;
+    const DELETE_REQUEST_TYPE = SubscriptionDeleteRequest::class;
+    final public static function uniqueSubscriptionString()
+    {
+        return 'test-' . Uuid::uuidv4();
+    }
+    final public static function defaultSubscriptionDraftFunction()
+    {
+        $uniqueSubscriptionString = self::uniqueSubscriptionString();
+        $uri = getenv('IRONMQ_URI');
+        $destination = Destination::ofUri($uri);
+        $messages = MessageSubscriptionCollection::of()->add(MessageSubscription::of()->setResourceTypeId('product'));
+        $key = 'test-' . $uniqueSubscriptionString;
+        $draft = SubscriptionDraft::ofKeyDestinationAndMessages($key, $destination, $messages);
+        return $draft;
+    }
+    final public static function defaultSubscriptionDraftBuilderFunction(SubscriptionDraft $draft)
+    {
+        return $draft;
+    }
+    final public static function defaultSubscriptionCreateFunction(ApiClient $client, SubscriptionDraft $draft)
+    {
+        return parent::defaultCreateFunction($client, self::CREATE_REQUEST_TYPE, $draft);
+    }
+    final public static function defaultSubscriptionDeleteFunction(ApiClient $client, Subscription $resource)
+    {
+        return parent::defaultDeleteFunction($client, self::DELETE_REQUEST_TYPE, $resource);
+    }
+    final public static function withUpdateableDraftSubscription(
+        ApiClient $client,
+        callable $draftBuilderFunction,
+        callable $assertFunction,
+        callable $createFunction = null,
+        callable $deleteFunction = null,
+        callable $draftFunction = null
+    ) {
+        if ($draftFunction == null) {
+            $draftFunction = [__CLASS__, 'defaultSubscriptionDraftFunction'];
+        }
+        if ($createFunction == null) {
+            $createFunction = [__CLASS__, 'defaultSubscriptionCreateFunction'];
+        }
+        if ($deleteFunction == null) {
+            $deleteFunction = [__CLASS__, 'defaultSubscriptionDeleteFunction'];
+        }
+        parent::withUpdateableDraftResource(
+            $client,
+            $draftBuilderFunction,
+            $assertFunction,
+            $createFunction,
+            $deleteFunction,
+            $draftFunction
+        );
+    }
+    final public static function withDraftSubscription(
+        ApiClient $client,
+        callable $draftBuilderFunction,
+        callable $assertFunction,
+        callable $createFunction = null,
+        callable $deleteFunction = null,
+        callable $draftFunction = null
+    ) {
+        if ($draftFunction == null) {
+            $draftFunction = [__CLASS__, 'defaultSubscriptionDraftFunction'];
+        }
+        if ($createFunction == null) {
+            $createFunction = [__CLASS__, 'defaultSubscriptionCreateFunction'];
+        }
+        if ($deleteFunction == null) {
+            $deleteFunction = [__CLASS__, 'defaultSubscriptionDeleteFunction'];
+        }
+        parent::withDraftResource(
+            $client,
+            $draftBuilderFunction,
+            $assertFunction,
+            $createFunction,
+            $deleteFunction,
+            $draftFunction
+        );
+    }
+    final public static function withSubscription(
+        ApiClient $client,
+        callable $assertFunction,
+        callable $createFunction = null,
+        callable $deleteFunction = null,
+        callable $draftFunction = null
+    ) {
+        self::withDraftSubscription(
+            $client,
+            [__CLASS__, 'defaultSubscriptionDraftBuilderFunction'],
+            $assertFunction,
+            $createFunction,
+            $deleteFunction,
+            $draftFunction
+        );
+    }
+    final public static function withUpdateableSubscription(
+        ApiClient $client,
+        callable $assertFunction,
+        callable $createFunction = null,
+        callable $deleteFunction = null,
+        callable $draftFunction = null
+    ) {
+        self::withUpdateableDraftSubscription(
+            $client,
+            [__CLASS__, 'defaultSubscriptionDraftBuilderFunction'],
+            $assertFunction,
+            $createFunction,
+            $deleteFunction,
+            $draftFunction
+        );
+    }
+}

--- a/tests/integration/Subscription/SubscriptionQueryRequestTest.php
+++ b/tests/integration/Subscription/SubscriptionQueryRequestTest.php
@@ -18,9 +18,11 @@ class SubscriptionQueryRequestTest extends ApiTestCase
             $this->markTestSkipped('Message Queue URL not configured');
         }
     }
+
     public function testQuery()
     {
         $client = $this->getApiClient();
+
         SubscriptionFixture::withSubscription(
             $client,
             function (Subscription $subscription) use ($client) {
@@ -28,35 +30,42 @@ class SubscriptionQueryRequestTest extends ApiTestCase
                     ->where('key=:key', ['key' => $subscription->getKey()]);
                 $response = $this->execute($client, $request);
                 $result = $request->mapFromResponse($response);
+
                 $this->assertCount(1, $result);
                 $this->assertInstanceOf(Subscription::class, $result->current());
                 $this->assertSame($subscription->getId(), $result->current()->getId());
             }
         );
     }
+
     public function testGetById()
     {
         $client = $this->getApiClient();
+
         SubscriptionFixture::withSubscription(
             $client,
             function (Subscription $subscription) use ($client) {
                 $request = RequestBuilder::of()->subscriptions()->getById($subscription->getId());
                 $response = $this->execute($client, $request);
                 $result = $request->mapFromResponse($response);
+
                 $this->assertInstanceOf(Subscription::class, $result);
                 $this->assertSame($subscription->getId(), $result->getId());
             }
         );
     }
+
     public function testGetByKey()
     {
         $client = $this->getApiClient();
+
         SubscriptionFixture::withSubscription(
             $client,
             function (Subscription $subscription) use ($client) {
                 $request = RequestBuilder::of()->subscriptions()->getByKey($subscription->getKey());
                 $response = $this->execute($client, $request);
                 $result = $request->mapFromResponse($response);
+
                 $this->assertInstanceOf(Subscription::class, $result);
                 $this->assertSame($subscription->getId(), $result->getId());
                 $this->assertSame($subscription->getKey(), $result->getKey());

--- a/tests/integration/Subscription/SubscriptionQueryRequestTest.php
+++ b/tests/integration/Subscription/SubscriptionQueryRequestTest.php
@@ -3,20 +3,11 @@
  * @author @jenschude <jens.schulze@commercetools.de>
  */
 
-
 namespace Commercetools\Core\IntegrationTests\Subscription;
 
+use Commercetools\Core\Builder\Request\RequestBuilder;
 use Commercetools\Core\IntegrationTests\ApiTestCase;
-use Commercetools\Core\Model\Subscription\IronMQDestination;
-use Commercetools\Core\Model\Subscription\MessageSubscription;
-use Commercetools\Core\Model\Subscription\MessageSubscriptionCollection;
 use Commercetools\Core\Model\Subscription\Subscription;
-use Commercetools\Core\Model\Subscription\SubscriptionDraft;
-use Commercetools\Core\Request\Subscriptions\SubscriptionByIdGetRequest;
-use Commercetools\Core\Request\Subscriptions\SubscriptionByKeyGetRequest;
-use Commercetools\Core\Request\Subscriptions\SubscriptionCreateRequest;
-use Commercetools\Core\Request\Subscriptions\SubscriptionDeleteRequest;
-use Commercetools\Core\Request\Subscriptions\SubscriptionQueryRequest;
 
 class SubscriptionQueryRequestTest extends ApiTestCase
 {
@@ -27,71 +18,49 @@ class SubscriptionQueryRequestTest extends ApiTestCase
             $this->markTestSkipped('Message Queue URL not configured');
         }
     }
-
-    /**
-     * @return SubscriptionDraft
-     */
-    protected function getDraft()
-    {
-        $uri = getenv('IRONMQ_URI');
-        $destination = IronMQDestination::ofUri($uri);
-        $messages = MessageSubscriptionCollection::of()->add(MessageSubscription::of()->setResourceTypeId('product'));
-        $key = 'test-' . $this->getTestRun();
-        $draft = SubscriptionDraft::ofKeyDestinationAndMessages($key, $destination, $messages);
-
-        return $draft;
-    }
-
-    protected function createSubscription(SubscriptionDraft $draft)
-    {
-        $request = SubscriptionCreateRequest::ofDraft($draft);
-        $response = $request->executeWithClient($this->getClient());
-        $subscription = $request->mapResponse($response);
-        $this->cleanupRequests[] = $this->deleteRequest = SubscriptionDeleteRequest::ofIdAndVersion(
-            $subscription->getId(),
-            $subscription->getVersion()
-        );
-
-        return $subscription;
-    }
-
     public function testQuery()
     {
-        $draft = $this->getDraft();
-        $subscription = $this->createSubscription($draft);
-
-        $request = SubscriptionQueryRequest::of()->where('key="' . $draft->getKey() . '"');
-        $response = $request->executeWithClient($this->getClient());
-        $result = $request->mapResponse($response);
-
-        $this->assertCount(1, $result);
-        $this->assertInstanceOf(Subscription::class, $result->getAt(0));
-        $this->assertSame($subscription->getId(), $result->getAt(0)->getId());
+        $client = $this->getApiClient();
+        SubscriptionFixture::withSubscription(
+            $client,
+            function (Subscription $subscription) use ($client) {
+                $request = RequestBuilder::of()->subscriptions()->query()
+                    ->where('key=:key', ['key' => $subscription->getKey()]);
+                $response = $this->execute($client, $request);
+                $result = $request->mapFromResponse($response);
+                $this->assertCount(1, $result);
+                $this->assertInstanceOf(Subscription::class, $result->current());
+                $this->assertSame($subscription->getId(), $result->current()->getId());
+            }
+        );
     }
-
     public function testGetById()
     {
-        $draft = $this->getDraft();
-        $subscription = $this->createSubscription($draft);
-
-        $request = SubscriptionByIdGetRequest::ofId($subscription->getId());
-        $response = $request->executeWithClient($this->getClient());
-        $result = $request->mapResponse($response);
-
-        $this->assertInstanceOf(Subscription::class, $subscription);
-        $this->assertSame($subscription->getId(), $result->getId());
+        $client = $this->getApiClient();
+        SubscriptionFixture::withSubscription(
+            $client,
+            function (Subscription $subscription) use ($client) {
+                $request = RequestBuilder::of()->subscriptions()->getById($subscription->getId());
+                $response = $this->execute($client, $request);
+                $result = $request->mapFromResponse($response);
+                $this->assertInstanceOf(Subscription::class, $result);
+                $this->assertSame($subscription->getId(), $result->getId());
+            }
+        );
     }
-
     public function testGetByKey()
     {
-        $draft = $this->getDraft();
-        $subscription = $this->createSubscription($draft);
-
-        $request = SubscriptionByKeyGetRequest::ofKey($subscription->getKey());
-        $response = $request->executeWithClient($this->getClient());
-        $result = $request->mapResponse($response);
-
-        $this->assertInstanceOf(Subscription::class, $subscription);
-        $this->assertSame($subscription->getId(), $result->getId());
+        $client = $this->getApiClient();
+        SubscriptionFixture::withSubscription(
+            $client,
+            function (Subscription $subscription) use ($client) {
+                $request = RequestBuilder::of()->subscriptions()->getByKey($subscription->getKey());
+                $response = $this->execute($client, $request);
+                $result = $request->mapFromResponse($response);
+                $this->assertInstanceOf(Subscription::class, $result);
+                $this->assertSame($subscription->getId(), $result->getId());
+                $this->assertSame($subscription->getKey(), $result->getKey());
+            }
+        );
     }
 }

--- a/tests/integration/Subscription/SubscriptionUpdateRequestTest.php
+++ b/tests/integration/Subscription/SubscriptionUpdateRequestTest.php
@@ -78,6 +78,7 @@ class SubscriptionUpdateRequestTest extends ApiTestCase
                 $result = $request->mapFromResponse($response);
 
                 $key = $this->getTestRun() . '-new';
+
                 $request = RequestBuilder::of()->subscriptions()->update($subscription)
                     ->addAction(SubscriptionSetKeyAction::of()->setKey($key));
                 $response = $this->execute($client, $request);

--- a/tests/integration/Subscription/SubscriptionUpdateRequestTest.php
+++ b/tests/integration/Subscription/SubscriptionUpdateRequestTest.php
@@ -3,27 +3,18 @@
  * @author @jenschude <jens.schulze@commercetools.de>
  */
 
-
 namespace Commercetools\Core\IntegrationTests\Subscription;
 
+use Commercetools\Core\Builder\Request\RequestBuilder;
 use Commercetools\Core\IntegrationTests\ApiTestCase;
 use Commercetools\Core\Model\Subscription\ChangeSubscription;
 use Commercetools\Core\Model\Subscription\ChangeSubscriptionCollection;
-use Commercetools\Core\Model\Subscription\IronMQDestination;
 use Commercetools\Core\Model\Subscription\MessageSubscription;
 use Commercetools\Core\Model\Subscription\MessageSubscriptionCollection;
 use Commercetools\Core\Model\Subscription\Subscription;
-use Commercetools\Core\Model\Subscription\SubscriptionDraft;
 use Commercetools\Core\Request\Subscriptions\Command\SubscriptionSetChangesAction;
 use Commercetools\Core\Request\Subscriptions\Command\SubscriptionSetKeyAction;
 use Commercetools\Core\Request\Subscriptions\Command\SubscriptionSetMessagesAction;
-use Commercetools\Core\Request\Subscriptions\SubscriptionByIdGetRequest;
-use Commercetools\Core\Request\Subscriptions\SubscriptionByKeyGetRequest;
-use Commercetools\Core\Request\Subscriptions\SubscriptionCreateRequest;
-use Commercetools\Core\Request\Subscriptions\SubscriptionDeleteRequest;
-use Commercetools\Core\Request\Subscriptions\SubscriptionQueryRequest;
-use Commercetools\Core\Request\Subscriptions\SubscriptionUpdateByKeyRequest;
-use Commercetools\Core\Request\Subscriptions\SubscriptionUpdateRequest;
 
 class SubscriptionUpdateRequestTest extends ApiTestCase
 {
@@ -34,137 +25,102 @@ class SubscriptionUpdateRequestTest extends ApiTestCase
             $this->markTestSkipped('Message Queue URL not configured');
         }
     }
-
-    /**
-     * @return SubscriptionDraft
-     */
-    protected function getDraft()
-    {
-        $uri = getenv('IRONMQ_URI');
-        $destination = IronMQDestination::ofUri($uri);
-        $messages = MessageSubscriptionCollection::of()->add(MessageSubscription::of()->setResourceTypeId('product'));
-        $key = 'test-' . $this->getTestRun();
-        $draft = SubscriptionDraft::ofKeyDestinationAndMessages($key, $destination, $messages);
-
-        return $draft;
-    }
-
-    protected function createSubscription(SubscriptionDraft $draft)
-    {
-        $request = SubscriptionCreateRequest::ofDraft($draft);
-        $response = $request->executeWithClient($this->getClient());
-        $subscription = $request->mapResponse($response);
-        $this->cleanupRequests[] = $this->deleteRequest = SubscriptionDeleteRequest::ofIdAndVersion(
-            $subscription->getId(),
-            $subscription->getVersion()
-        );
-
-        return $subscription;
-    }
-
     public function testUpdateByKey()
     {
-        $draft = $this->getDraft();
-        $subscription = $this->createSubscription($draft);
-
-        $request = SubscriptionUpdateByKeyRequest::ofKeyAndVersion(
-            $subscription->getKey(),
-            $subscription->getVersion()
+        $client = $this->getApiClient();
+        SubscriptionFixture::withUpdateableSubscription(
+            $client,
+            function (Subscription $subscription) use ($client) {
+                $request = RequestBuilder::of()->subscriptions()->updateByKey($subscription);
+                $response = $this->execute($client, $request);
+                $result = $request->mapFromResponse($response);
+                $this->assertInstanceOf(Subscription::class, $result);
+                $this->assertSame($subscription->getId(), $result->getId());
+                $this->assertNotSame($subscription->getVersion(), $result->getVersion());
+                return $result;
+            }
         );
-        $response = $request->executeWithClient($this->getClient());
-        $result = $request->mapResponse($response);
-        $this->deleteRequest->setVersion($result->getVersion());
-
-        $this->assertInstanceOf(Subscription::class, $result);
     }
-
     public function testUpdateById()
     {
-        $draft = $this->getDraft();
-        $subscription = $this->createSubscription($draft);
-
-        $request = SubscriptionUpdateRequest::ofIdAndVersion(
-            $subscription->getId(),
-            $subscription->getVersion()
+        $client = $this->getApiClient();
+        SubscriptionFixture::withUpdateableSubscription(
+            $client,
+            function (Subscription $subscription) use ($client) {
+                $request = RequestBuilder::of()->subscriptions()->update($subscription);
+                $response = $this->execute($client, $request);
+                $result = $request->mapFromResponse($response);
+                $this->assertInstanceOf(Subscription::class, $result);
+                $this->assertSame($subscription->getId(), $result->getId());
+                $this->assertNotSame($subscription->getVersion(), $result->getVersion());
+                return $result;
+            }
         );
-        $response = $request->executeWithClient($this->getClient());
-        $result = $request->mapResponse($response);
-        $this->deleteRequest->setVersion($result->getVersion());
-
-        $this->assertInstanceOf(Subscription::class, $result);
     }
-
     public function testUpdateKey()
     {
-        $draft = $this->getDraft();
-        $subscription = $this->createSubscription($draft);
-
-        $request = SubscriptionUpdateRequest::ofIdAndVersion(
-            $subscription->getId(),
-            $subscription->getVersion()
+        $client = $this->getApiClient();
+        SubscriptionFixture::withUpdateableSubscription(
+            $client,
+            function (Subscription $subscription) use ($client) {
+                $request = RequestBuilder::of()->subscriptions()->update($subscription);
+                $response = $this->execute($client, $request);
+                $result = $request->mapFromResponse($response);
+                $key = $this->getTestRun() . '-new';
+                $request = RequestBuilder::of()->subscriptions()->update($subscription)
+                    ->addAction(SubscriptionSetKeyAction::of()->setKey($key));
+                $response = $this->execute($client, $request);
+                $result = $request->mapFromResponse($response);
+                $this->assertInstanceOf(Subscription::class, $result);
+                $this->assertSame($key, $result->getKey());
+                return $result;
+            }
         );
-
-        $key = $this->getTestRun() . '-new';
-        $request->addAction(
-            SubscriptionSetKeyAction::of()->setKey($key)
-        );
-        $response = $request->executeWithClient($this->getClient());
-        $result = $request->mapResponse($response);
-        $this->deleteRequest->setVersion($result->getVersion());
-
-        $this->assertInstanceOf(Subscription::class, $result);
-        $this->assertSame($key, $result->getKey());
     }
-
     public function testUpdateMessages()
     {
-        $draft = $this->getDraft();
-        $subscription = $this->createSubscription($draft);
-
-        $request = SubscriptionUpdateRequest::ofIdAndVersion(
-            $subscription->getId(),
-            $subscription->getVersion()
+        $client = $this->getApiClient();
+        SubscriptionFixture::withUpdateableSubscription(
+            $client,
+            function (Subscription $subscription) use ($client) {
+                $request = RequestBuilder::of()->subscriptions()->update($subscription)
+                    ->addAction(
+                        SubscriptionSetMessagesAction::of()->setMessages(
+                            MessageSubscriptionCollection::of()->add(
+                                MessageSubscription::of()->setResourceTypeId('order')
+                            )
+                        )
+                    );
+                $response = $this->execute($client, $request);
+                $result = $request->mapFromResponse($response);
+                $this->assertInstanceOf(Subscription::class, $result);
+                $this->assertCount(1, $result->getMessages());
+                $this->assertSame('order', $result->getMessages()->current()->getResourceTypeId());
+                return $result;
+            }
         );
-
-        $request->addAction(
-            SubscriptionSetMessagesAction::of()->setMessages(
-                MessageSubscriptionCollection::of()->add(
-                    MessageSubscription::of()->setResourceTypeId('order')
-                )
-            )
-        );
-        $response = $request->executeWithClient($this->getClient());
-        $result = $request->mapResponse($response);
-        $this->deleteRequest->setVersion($result->getVersion());
-
-        $this->assertInstanceOf(Subscription::class, $result);
-        $this->assertCount(1, $result->getMessages());
-        $this->assertSame('order', $result->getMessages()->current()->getResourceTypeId());
     }
-
     public function testUpdateChanges()
     {
-        $draft = $this->getDraft();
-        $subscription = $this->createSubscription($draft);
-
-        $request = SubscriptionUpdateRequest::ofIdAndVersion(
-            $subscription->getId(),
-            $subscription->getVersion()
+        $client = $this->getApiClient();
+        SubscriptionFixture::withUpdateableSubscription(
+            $client,
+            function (Subscription $subscription) use ($client) {
+                $request = RequestBuilder::of()->subscriptions()->update($subscription)
+                    ->addAction(
+                        SubscriptionSetChangesAction::of()->setChanges(
+                            ChangeSubscriptionCollection::of()->add(
+                                ChangeSubscription::of()->setResourceTypeId('product')
+                            )
+                        )
+                    );
+                $response = $this->execute($client, $request);
+                $result = $request->mapFromResponse($response);
+                $this->assertInstanceOf(Subscription::class, $result);
+                $this->assertCount(1, $result->getMessages());
+                $this->assertSame('product', $result->getChanges()->current()->getResourceTypeId());
+                return $result;
+            }
         );
-
-        $request->addAction(
-            SubscriptionSetChangesAction::of()->setChanges(
-                ChangeSubscriptionCollection::of()->add(
-                    ChangeSubscription::of()->setResourceTypeId('product')
-                )
-            )
-        );
-        $response = $request->executeWithClient($this->getClient());
-        $result = $request->mapResponse($response);
-        $this->deleteRequest->setVersion($result->getVersion());
-
-        $this->assertInstanceOf(Subscription::class, $result);
-        $this->assertCount(1, $result->getMessages());
-        $this->assertSame('product', $result->getChanges()->current()->getResourceTypeId());
     }
 }

--- a/tests/integration/Subscription/SubscriptionUpdateRequestTest.php
+++ b/tests/integration/Subscription/SubscriptionUpdateRequestTest.php
@@ -25,61 +25,76 @@ class SubscriptionUpdateRequestTest extends ApiTestCase
             $this->markTestSkipped('Message Queue URL not configured');
         }
     }
+
     public function testUpdateByKey()
     {
         $client = $this->getApiClient();
+
         SubscriptionFixture::withUpdateableSubscription(
             $client,
             function (Subscription $subscription) use ($client) {
                 $request = RequestBuilder::of()->subscriptions()->updateByKey($subscription);
                 $response = $this->execute($client, $request);
                 $result = $request->mapFromResponse($response);
+
                 $this->assertInstanceOf(Subscription::class, $result);
                 $this->assertSame($subscription->getId(), $result->getId());
                 $this->assertNotSame($subscription->getVersion(), $result->getVersion());
+
                 return $result;
             }
         );
     }
+
     public function testUpdateById()
     {
         $client = $this->getApiClient();
+
         SubscriptionFixture::withUpdateableSubscription(
             $client,
             function (Subscription $subscription) use ($client) {
                 $request = RequestBuilder::of()->subscriptions()->update($subscription);
                 $response = $this->execute($client, $request);
                 $result = $request->mapFromResponse($response);
+
                 $this->assertInstanceOf(Subscription::class, $result);
                 $this->assertSame($subscription->getId(), $result->getId());
                 $this->assertNotSame($subscription->getVersion(), $result->getVersion());
+
                 return $result;
             }
         );
     }
+
     public function testUpdateKey()
     {
         $client = $this->getApiClient();
+
         SubscriptionFixture::withUpdateableSubscription(
             $client,
             function (Subscription $subscription) use ($client) {
                 $request = RequestBuilder::of()->subscriptions()->update($subscription);
                 $response = $this->execute($client, $request);
                 $result = $request->mapFromResponse($response);
+
                 $key = $this->getTestRun() . '-new';
                 $request = RequestBuilder::of()->subscriptions()->update($subscription)
                     ->addAction(SubscriptionSetKeyAction::of()->setKey($key));
                 $response = $this->execute($client, $request);
                 $result = $request->mapFromResponse($response);
+
                 $this->assertInstanceOf(Subscription::class, $result);
                 $this->assertSame($key, $result->getKey());
+
                 return $result;
             }
         );
     }
+
     public function testUpdateMessages()
     {
         $client = $this->getApiClient();
+
         SubscriptionFixture::withUpdateableSubscription(
             $client,
             function (Subscription $subscription) use ($client) {
@@ -93,16 +108,20 @@ class SubscriptionUpdateRequestTest extends ApiTestCase
                     );
                 $response = $this->execute($client, $request);
                 $result = $request->mapFromResponse($response);
+
                 $this->assertInstanceOf(Subscription::class, $result);
                 $this->assertCount(1, $result->getMessages());
                 $this->assertSame('order', $result->getMessages()->current()->getResourceTypeId());
+
                 return $result;
             }
         );
     }
+
     public function testUpdateChanges()
     {
         $client = $this->getApiClient();
+
         SubscriptionFixture::withUpdateableSubscription(
             $client,
             function (Subscription $subscription) use ($client) {
@@ -116,9 +135,11 @@ class SubscriptionUpdateRequestTest extends ApiTestCase
                     );
                 $response = $this->execute($client, $request);
                 $result = $request->mapFromResponse($response);
+
                 $this->assertInstanceOf(Subscription::class, $result);
                 $this->assertCount(1, $result->getMessages());
                 $this->assertSame('product', $result->getChanges()->current()->getResourceTypeId());
+
                 return $result;
             }
         );

--- a/tests/integration/Subscription/SubscriptionUpdateRequestTest.php
+++ b/tests/integration/Subscription/SubscriptionUpdateRequestTest.php
@@ -77,7 +77,7 @@ class SubscriptionUpdateRequestTest extends ApiTestCase
                 $response = $this->execute($client, $request);
                 $result = $request->mapFromResponse($response);
 
-                $key = $this->getTestRun() . '-new';
+                $key = 'new' . SubscriptionFixture::uniqueSubscriptionString();
 
                 $request = RequestBuilder::of()->subscriptions()->update($subscription)
                     ->addAction(SubscriptionSetKeyAction::of()->setKey($key));


### PR DESCRIPTION
not sure if it has to be done or not. Right now these tests are skipped and it has to be changed the logic behind the method Destination::ofUri. To check with @jenschude

1. code and add tests that cover the created code. Your code should be warning-free.
   * [ ] tests existing
1. stick to PSR-2 and and don't reformat existing code.
   * [ ] code style check succesful
