### PR TITLE
PHPUnit 8 fixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,10 +117,6 @@ jobs:
         if: matrix.dependencies == 'lowest'
         run: ./set_guzzle5.sh
 
-      - name: Set PHPUnit5
-        if: matrix.php-version == '5.6'
-        run: sed -i "/symplify/d" composer.json &&  ./set_phpunit5.sh
-
       - name: Install lowest dependencies with composer
         if: matrix.dependencies == 'lowest'
         run: composer update --no-ansi --no-interaction --no-progress --no-suggest --prefer-lowest
@@ -130,15 +126,9 @@ jobs:
         run: composer update --no-ansi --no-interaction --no-progress --no-suggest
 
       - name: Run tests with phpunit
-        if: matrix.php-version != '5.6'
         run: vendor/bin/phpunit --testsuite=unit --coverage-clover=coverage.xml
 
-      - name: Run tests with phpunit5
-        if: matrix.php-version == '5.6'
-        run: vendor/bin/phpunit -c phpunit5.xml.dist --testsuite=unit
-
       - name: Send code coverage report to Codecov.io
-        if: matrix.php-version != '5.6'
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         run: bash <(curl -s https://codecov.io/bash) || true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -82,7 +82,7 @@ jobs:
     strategy:
       matrix:
         php-version:
-          - "5.6"
+#          - "5.6"
           - "7.2"
           - "7.3"
           - "7.4"

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,39 +12,38 @@ cache:
   directories:
   - vendor
 before_install:
-- openssl aes-256-cbc -K $encrypted_17acaeff100f_key -iv $encrypted_17acaeff100f_iv -in github_deploy_key.enc -out github_deploy_key -d
-- chmod 600 github_deploy_key
-- eval $(ssh-agent -s)
-- ssh-add github_deploy_key
-- rm github_deploy_key
+#- openssl aes-256-cbc -K $encrypted_17acaeff100f_key -iv $encrypted_17acaeff100f_iv -in github_deploy_key.enc -out github_deploy_key -d
+#- chmod 600 github_deploy_key
+#- eval $(ssh-agent -s)
+#- ssh-add github_deploy_key
+#- rm github_deploy_key
 - PHP=$TRAVIS_PHP_VERSION
 - echo "extension = redis.so" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini
 before_script:
 - composer config -g github-oauth.github.com $GITHUB_OAUTH_TOKEN
-- sed -i '/symplify/d' composer.json
 - if [ $GUZZLE == '5' ] ; then ./set_guzzle5.sh; fi
 - if [ $GUZZLE == '5' ] ; then composer update -o --prefer-dist --prefer-lowest; else composer install -o --prefer-dist; fi
 script:
 - vendor/bin/phpunit --testsuite=unit
 - if [ $GUZZLE == '6' ] && [ $TRAVIS_PULL_REQUEST == 'false' ]; then vendor/bin/phpunit --testsuite=integration; fi
-- bin/ctp-tlscheck.php
-before_deploy:
-  - if [ $GUZZLE == '5' ] ; then ./install-apigen.sh && php apigen.phar generate --debug --config build/apigen.neon; fi
-deploy:
-  - provider: script
-    skip_cleanup: true
-    script: ./push-docs-to-gh-pages.sh
-    on:
-      branch: master
-      condition: $GUZZLE = '6'
-      php: 7.4
-  - provider: script
-    skip_cleanup: true
-    script: ./push-docs-to-gh-pages.sh
-    on:
-      tags: true
-      condition: $GUZZLE = '6'
-      php: 7.4
+#- bin/ctp-tlscheck.php
+#before_deploy:
+#  - if [ $GUZZLE == '5' ] ; then ./install-apigen.sh && php apigen.phar generate --debug --config build/apigen.neon; fi
+#deploy:
+#  - provider: script
+#    skip_cleanup: true
+#    script: ./push-docs-to-gh-pages.sh
+#    on:
+#      branch: master
+#      condition: $GUZZLE = '6'
+#      php: 7.4
+#  - provider: script
+#    skip_cleanup: true
+#    script: ./push-docs-to-gh-pages.sh
+#    on:
+#      tags: true
+#      condition: $GUZZLE = '6'
+#      php: 7.4
 notifications:
   hipchat:
     rooms:

--- a/tests/integration/Category/CategoryUpdateRequestTest.php
+++ b/tests/integration/Category/CategoryUpdateRequestTest.php
@@ -562,7 +562,7 @@ class CategoryUpdateRequestTest extends ApiTestCase
                 $result = $request->mapFromResponse($response);
 
                 $this->assertInstanceOf(Category::class, $result);
-                $this->assertContains(
+                $this->assertStringContainsString(
                     $newSource->getUri(),
                     $result->getAssets()->current()->getSources()->current()->getUri()
                 );
@@ -806,7 +806,7 @@ class CategoryUpdateRequestTest extends ApiTestCase
                 $result = $request->mapFromResponse($response);
 
                 $this->assertInstanceOf(Category::class, $result);
-                $this->assertContains(
+                $this->assertStringContainsString(
                     $newSource->getUri(),
                     $result->getAssets()->current()->getSources()->current()->getUri()
                 );

--- a/tests/integration/ClientFactoryTest.php
+++ b/tests/integration/ClientFactoryTest.php
@@ -14,6 +14,7 @@ use Commercetools\Core\Error\ErrorContainer;
 use Commercetools\Core\Error\ErrorResponseException;
 use Commercetools\Core\Error\InvalidClientCredentialsException;
 use Commercetools\Core\Error\InvalidOperationError;
+use Commercetools\Core\Error\NotFoundException;
 use Commercetools\Core\Model\Category\CategoryCollection;
 use Commercetools\Core\Request\Categories\CategoryByIdGetRequest;
 use Commercetools\Core\Request\Categories\CategoryQueryRequest;
@@ -71,7 +72,7 @@ class ClientFactoryTest extends ApiTestCase
 
         $record = current($handler->getRecords());
         $this->assertStringStartsWith($config->getProject(), $record['context']['X-Correlation-ID'][0]);
-        $this->assertContains((new UserAgentProvider())->getUserAgent(), $record['message']);
+        $this->assertStringContainsString((new UserAgentProvider())->getUserAgent(), $record['message']);
     }
 
     public function testExecute()
@@ -97,7 +98,7 @@ class ClientFactoryTest extends ApiTestCase
 
         $record = current($handler->getRecords());
         $this->assertStringStartsWith($config->getProject(), $record['context']['X-Correlation-ID'][0]);
-        $this->assertContains((new UserAgentProvider())->getUserAgent(), $record['message']);
+        $this->assertStringContainsString((new UserAgentProvider())->getUserAgent(), $record['message']);
     }
 
     public function testExecuteAsync()
@@ -123,7 +124,7 @@ class ClientFactoryTest extends ApiTestCase
 
         $record = current($handler->getRecords());
         $this->assertStringStartsWith($config->getProject(), $record['context']['X-Correlation-ID'][0]);
-        $this->assertContains((new UserAgentProvider())->getUserAgent(), $record['message']);
+        $this->assertStringContainsString((new UserAgentProvider())->getUserAgent(), $record['message']);
     }
 
     public function testClientNoException()
@@ -148,9 +149,6 @@ class ClientFactoryTest extends ApiTestCase
         $this->assertNull($category);
     }
 
-    /**
-     * @expectedException \Commercetools\Core\Error\NotFoundException
-     */
     public function testClientException()
     {
         $handler = new TestHandler();
@@ -165,6 +163,7 @@ class ClientFactoryTest extends ApiTestCase
         $this->assertInstanceOf(ApiClient::class, $client);
 
         $request = CategoryByIdGetRequest::ofId("abc");
+        $this->expectException(NotFoundException::class);
         $client->send($request->httpRequest());
     }
 
@@ -226,7 +225,7 @@ class ClientFactoryTest extends ApiTestCase
 
         $record = current($handler->getRecords());
         $this->assertStringStartsWith($config->getProject(), $record['context']['X-Correlation-ID'][0]);
-        $this->assertContains((new UserAgentProvider())->getUserAgent(), $record['message']);
+        $this->assertStringContainsString((new UserAgentProvider())->getUserAgent(), $record['message']);
     }
 
     public function testPreAuthProvider()

--- a/tests/integration/ClientTest.php
+++ b/tests/integration/ClientTest.php
@@ -78,7 +78,7 @@ class ClientTest extends ApiTestCase
         $record = current($logHandler->getRecords());
 
         $this->assertTrue($logHandler->hasInfo($record));
-        $this->assertContains('/'.$clientConfig->getProject().'/ HTTP/1.1" 200', (string)$record['message']);
+        $this->assertStringContainsString('/'.$clientConfig->getProject().'/ HTTP/1.1" 200', (string)$record['message']);
         $this->assertStringStartsWith($clientConfig->getProject(), current($record['context'][AbstractApiResponse::X_CORRELATION_ID]));
         $this->assertSame(Logger::INFO, $record['level']);
     }

--- a/tests/integration/CustomObject/CustomObjectQueryRequestTest.php
+++ b/tests/integration/CustomObject/CustomObjectQueryRequestTest.php
@@ -95,9 +95,6 @@ class CustomObjectQueryRequestTest extends ApiTestCase
         );
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testInvalidType()
     {
         $client = $this->getApiClient();
@@ -105,6 +102,7 @@ class CustomObjectQueryRequestTest extends ApiTestCase
         CustomObjectFixture::withCustomObject(
             $client,
             function (CustomObject $customObject) use ($client) {
+                $this->expectException(\InvalidArgumentException::class);
                 RequestBuilder::of()->customObjects()->create(new \stdClass());
             }
         );

--- a/tests/integration/Extension/ExtensionFixture.php
+++ b/tests/integration/Extension/ExtensionFixture.php
@@ -15,6 +15,7 @@ use Commercetools\Core\Request\Extensions\ExtensionDeleteRequest;
 
 class ExtensionFixture extends ResourceFixture
 {
+    const EXTENSION_RESPONDER = 'https://1i4axkp5vh.execute-api.eu-west-1.amazonaws.com/dev';
     const CREATE_REQUEST_TYPE = ExtensionCreateRequest::class;
     const DELETE_REQUEST_TYPE = ExtensionDeleteRequest::class;
 
@@ -27,7 +28,7 @@ class ExtensionFixture extends ResourceFixture
     {
         $uniqueExtensionString = self::uniqueExtensionString();
         $draft = ExtensionDraft::ofDestinationAndTriggers(
-            HttpDestination::of()->setUrl('https://api.europe-west1.gcp.commercetools.com'),
+            HttpDestination::of()->setUrl(self::EXTENSION_RESPONDER),
             TriggerCollection::of()->add(
                 Trigger::of()->setResourceTypeId('cart')->setActions([Trigger::ACTION_CREATE])
             )

--- a/tests/integration/Extension/ExtensionUpdateRequestTest.php
+++ b/tests/integration/Extension/ExtensionUpdateRequestTest.php
@@ -103,10 +103,11 @@ class ExtensionUpdateRequestTest extends ApiTestCase
         ExtensionFixture::withUpdateableExtension(
             $client,
             function (Extension $extension) use ($client) {
+                $url = ExtensionFixture::EXTENSION_RESPONDER . '/test';
                 $request = RequestBuilder::of()->extensions()->update($extension)
                     ->addAction(
                         ExtensionChangeDestinationAction::of()->setDestination(
-                            HttpDestination::of()->setUrl('https://api.commercetools.com')
+                            HttpDestination::of()->setUrl($url)
                         )
                     );
                 $response = $this->execute($client, $request);
@@ -114,7 +115,7 @@ class ExtensionUpdateRequestTest extends ApiTestCase
 
                 $this->assertNotSame($extension->getVersion(), $result->getVersion());
                 $this->assertInstanceOf(Extension::class, $result);
-                $this->assertSame('https://api.commercetools.com', $result->getDestination()->getUrl());
+                $this->assertSame($url, $result->getDestination()->getUrl());
 
                 return $result;
             }

--- a/tests/integration/ManagerTest.php
+++ b/tests/integration/ManagerTest.php
@@ -25,7 +25,7 @@ class ManagerTest extends ApiTestCase
         $this->assertEmpty($config->getScope());
         $this->assertNotEmpty($token->getScope());
         $this->assertNotEmpty($token->getToken());
-        $this->assertContains('manage_project', $token->getScope());
+        $this->assertStringContainsString('manage_project', $token->getScope());
     }
 
     public function testCorrelationId()

--- a/tests/integration/Me/MeCartRequestTest.php
+++ b/tests/integration/Me/MeCartRequestTest.php
@@ -7,6 +7,7 @@
 namespace Commercetools\Core\IntegrationTests\Me;
 
 use Commercetools\Core\Client\ClientFactory;
+use Commercetools\Core\Error\BadRequestException;
 use Commercetools\Core\Fixtures\AnonymousId;
 use Commercetools\Core\IntegrationTests\ApiTestCase;
 use Commercetools\Core\Client;
@@ -124,7 +125,7 @@ class MeCartRequestTest extends ApiTestCase
         $this->assertSame($token->getToken(), $manager->getToken()->getToken());
 
         $this->assertCount(1, $testHandler->getRecords());
-        $this->assertContains('anonymous', current($testHandler->getRecords())['message']);
+        $this->assertStringContainsString('anonymous', current($testHandler->getRecords())['message']);
     }
 
     public function testCustomerOAuth()
@@ -249,9 +250,6 @@ class MeCartRequestTest extends ApiTestCase
         $this->assertSame($cart->getAnonymousId(), $result->getById($cart->getId())->getAnonymousId());
     }
 
-    /**
-     * @expectedException \Commercetools\Core\Error\BadRequestException
-     */
     public function testAnonCartExistsForId()
     {
         $anonId = uniqid();
@@ -265,6 +263,7 @@ class MeCartRequestTest extends ApiTestCase
 
         $manager = new Manager($config, $this->getCache());
         $manager->getHttpClient(['verify' => $this->getVerifySSL()]);
+        $this->expectException(BadRequestException::class);
         $manager->refreshToken();
     }
 
@@ -344,7 +343,7 @@ class MeCartRequestTest extends ApiTestCase
         $response = $request->executeWithClient($client);
         $result = $request->mapResponse($response);
 
-        $this->assertContains('customers/token', current($handler->getRecords())['message']);
+        $this->assertStringContainsString('customers/token', current($handler->getRecords())['message']);
         $this->assertSame($cart->getId(), $result->getId());
     }
 
@@ -488,7 +487,7 @@ class MeCartRequestTest extends ApiTestCase
         $response = $request->executeWithClient($client);
         $result = $request->mapResponse($response);
 
-        $this->assertContains('customers/token', current($handler->getRecords())['message']);
+        $this->assertStringContainsString('customers/token', current($handler->getRecords())['message']);
         $this->assertSame($cart1->getId(), $result->getId());
 
         $cartDraft = $this->getMyCartDraft();
@@ -547,7 +546,7 @@ class MeCartRequestTest extends ApiTestCase
         $request = MeActiveCartRequest::of();
         $response = $request->executeWithClient($client);
 
-        $this->assertContains('customers/token', current($handler->getRecords())['message']);
+        $this->assertStringContainsString('customers/token', current($handler->getRecords())['message']);
 
         $this->assertTrue($response->isError());
         $this->assertInstanceOf(

--- a/tests/integration/Me/MeOrderRequestTest.php
+++ b/tests/integration/Me/MeOrderRequestTest.php
@@ -180,7 +180,7 @@ class MeOrderRequestTest extends ApiTestCase
         $response = $request->executeWithClient($client);
         $result = $request->mapResponse($response);
 
-        $this->assertContains('customers/token', current($handler->getRecords())['message']);
+        $this->assertStringContainsString('customers/token', current($handler->getRecords())['message']);
         $this->assertSame($order->getId(), $result->getId());
     }
 
@@ -211,7 +211,7 @@ class MeOrderRequestTest extends ApiTestCase
         $request = MeOrderByIdRequest::ofId($order->getId());
         $response = $request->executeWithClient($client);
 
-        $this->assertContains('customers/token', current($handler->getRecords())['message']);
+        $this->assertStringContainsString('customers/token', current($handler->getRecords())['message']);
         $this->assertTrue($response->isError());
         $this->assertInstanceOf(ResourceNotFoundError::class, $response->getErrors()->current());
     }

--- a/tests/integration/Me/MeRequestTest.php
+++ b/tests/integration/Me/MeRequestTest.php
@@ -55,7 +55,7 @@ class MeRequestTest extends ApiTestCase
         $response = $request->executeWithClient($client);
         $result = $request->mapResponse($response);
 
-        $this->assertContains('customers/token', current($handler->getRecords())['message']);
+        $this->assertStringContainsString('customers/token', current($handler->getRecords())['message']);
         $this->assertSame($customer->getId(), $result->getId());
     }
 
@@ -89,7 +89,7 @@ class MeRequestTest extends ApiTestCase
         $response = $request->executeWithClient($client);
         $result = $request->mapResponse($response);
 
-        $this->assertContains('customers/token', current($handler->getRecords())['message']);
+        $this->assertStringContainsString('customers/token', current($handler->getRecords())['message']);
         $this->assertSame($customer->getId(), $result->getId());
         TestHelper::getInstance($this->getClient())->setCustomer($result);
 
@@ -125,7 +125,7 @@ class MeRequestTest extends ApiTestCase
         $response = $request->executeWithClient($client);
         $result = $request->mapResponse($response);
 
-        $this->assertContains('customers/token', current($handler->getRecords())['message']);
+        $this->assertStringContainsString('customers/token', current($handler->getRecords())['message']);
         $this->assertSame($customer->getId(), $result->getId());
         TestHelper::getInstance($this->getClient())->setCustomer($result);
 
@@ -135,7 +135,7 @@ class MeRequestTest extends ApiTestCase
         $response = $request->executeWithClient($client);
         $result = $request->mapResponse($response);
 
-        $this->assertContains('customers/token', current($handler->getRecords())['message']);
+        $this->assertStringContainsString('customers/token', current($handler->getRecords())['message']);
         $this->assertSame($customer->getId(), $result->getId());
     }
 
@@ -172,7 +172,7 @@ class MeRequestTest extends ApiTestCase
         $response = $request->executeWithClient($client);
         $result = $request->mapResponse($response);
 
-        $this->assertContains('anonymous/token', current($handler->getRecords())['message']);
+        $this->assertStringContainsString('anonymous/token', current($handler->getRecords())['message']);
         $this->assertSame($customer->getId(), $result->getId());
         TestHelper::getInstance($this->getClient())->setCustomer($result);
 
@@ -194,7 +194,7 @@ class MeRequestTest extends ApiTestCase
         $response = $request->executeWithClient($client);
         $result = $request->mapResponse($response);
 
-        $this->assertContains('customers/token', current($handler->getRecords())['message']);
+        $this->assertStringContainsString('customers/token', current($handler->getRecords())['message']);
         $this->assertSame($customer->getId(), $result->getId());
     }
 

--- a/tests/integration/Me/MeRequestTest.php
+++ b/tests/integration/Me/MeRequestTest.php
@@ -6,6 +6,7 @@
 
 namespace Commercetools\Core\IntegrationTests\Me;
 
+use Commercetools\Core\Error\BadRequestException;
 use Commercetools\Core\IntegrationTests\ApiTestCase;
 use Commercetools\Core\Client;
 use Commercetools\Core\Config;
@@ -59,9 +60,6 @@ class MeRequestTest extends ApiTestCase
         $this->assertSame($customer->getId(), $result->getId());
     }
 
-    /**
-     * @expectedException \Commercetools\Core\Error\BadRequestException
-     */
     public function testPasswordChangeRevokeToken()
     {
         $customerDraft = $this->getCustomerDraft();
@@ -94,6 +92,7 @@ class MeRequestTest extends ApiTestCase
         TestHelper::getInstance($this->getClient())->setCustomer($result);
 
         $request = MeGetRequest::of();
+        $this->expectException(BadRequestException::class);
         $request->executeWithClient($client);
     }
 

--- a/tests/unit/Cache/CacheAdapterFactoryTest.php
+++ b/tests/unit/Cache/CacheAdapterFactoryTest.php
@@ -10,6 +10,7 @@ use Cache\Adapter\Doctrine\DoctrineCachePool;
 use Cache\Adapter\Filesystem\FilesystemCachePool;
 use Cache\Adapter\PHPArray\ArrayCachePool;
 use Cache\Adapter\Redis\RedisCachePool;
+use Commercetools\Core\Error\InvalidArgumentException;
 use Doctrine\Common\Cache\ArrayCache;
 use Psr\SimpleCache\CacheInterface;
 
@@ -84,21 +85,19 @@ class CacheAdapterFactoryTest extends \PHPUnit\Framework\TestCase
 
     /**
      * test correct type handling
-     *
-     * @expectedException \Commercetools\Core\Error\InvalidArgumentException
      */
     public function testNoObjectException()
     {
+        $this->expectException(InvalidArgumentException::class);
         $this->getFactory()->get([]);
     }
 
     /**
      * test correct type handling
-     *
-     * @expectedException \Commercetools\Core\Error\InvalidArgumentException
      */
     public function testNoAdapterException()
     {
+        $this->expectException(InvalidArgumentException::class);
         $this->getFactory()->get(new \ArrayObject());
     }
 

--- a/tests/unit/Client/OAuth/ManagerTest.php
+++ b/tests/unit/Client/OAuth/ManagerTest.php
@@ -11,6 +11,7 @@ use Cache\Adapter\PHPArray\ArrayCachePool;
 use Cache\Adapter\Void\VoidCachePool;
 use Commercetools\Core\Cache\CacheAdapterFactory;
 use Commercetools\Core\Client\Adapter\ConfigAware;
+use Commercetools\Core\Error\InvalidClientCredentialsException;
 use GuzzleHttp\Client as HttpClient;
 use GuzzleHttp\Handler\MockHandler;
 use GuzzleHttp\HandlerStack;
@@ -248,9 +249,6 @@ class ManagerTest extends \PHPUnit\Framework\TestCase
     }
 
 
-    /**
-     * @expectedException \Commercetools\Core\Error\InvalidClientCredentialsException
-     */
     public function testError()
     {
         $manager = $this->getManager(
@@ -264,6 +262,7 @@ class ManagerTest extends \PHPUnit\Framework\TestCase
             true
         );
 
+        $this->expectException(InvalidClientCredentialsException::class);
         /**
          * @var Manager $manager
          */

--- a/tests/unit/ClientTest.php
+++ b/tests/unit/ClientTest.php
@@ -9,6 +9,7 @@ namespace Commercetools\Core;
 use Commercetools\Core\Client\Adapter\AdapterOptionInterface;
 use Commercetools\Core\Client\Adapter\ConfigAware;
 use Commercetools\Core\Client\OAuth\Manager;
+use Commercetools\Core\Error\ApiException;
 use Commercetools\Core\Error\BadGatewayException;
 use Commercetools\Core\Error\ConcurrentModificationException;
 use Commercetools\Core\Error\ErrorContainer;
@@ -226,9 +227,6 @@ class ClientTest extends \PHPUnit\Framework\TestCase
         $this->assertTrue($response->isError());
     }
 
-    /**
-     * @expectedException \Commercetools\Core\Error\ApiException
-     */
     public function testUnexpectedException()
     {
         $oauthMockBuilder = $this->getMockBuilder(Manager::class);
@@ -255,6 +253,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
             [$endpoint, 'id']
         );
 
+        $this->expectException(ApiException::class);
         $clientMock->execute($request);
     }
 
@@ -317,7 +316,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
         $record = current($handler->getRecords());
 
         $this->assertTrue($handler->hasInfo($record));
-        $this->assertContains('GET /project/test/id', (string)$record['message']);
+        $this->assertStringContainsString('GET /project/test/id', (string)$record['message']);
         $this->assertSame(Logger::INFO, $record['level']);
     }
 
@@ -340,7 +339,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
 
         $record = current($handler->getRecords());
         $this->assertTrue($handler->hasDebug($record));
-        $this->assertContains('GET /project/test/id', (string)$record['message']);
+        $this->assertStringContainsString('GET /project/test/id', (string)$record['message']);
         $this->assertSame(Logger::DEBUG, $record['level']);
     }
 
@@ -363,7 +362,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
 
         $record = current($handler->getRecords());
         $this->assertTrue($handler->hasInfo($record));
-        $this->assertContains('GET /project/test/id', (string)$record['message']);
+        $this->assertStringContainsString('GET /project/test/id', (string)$record['message']);
         $this->assertSame(Logger::INFO, $record['level']);
     }
 
@@ -514,9 +513,6 @@ class ClientTest extends \PHPUnit\Framework\TestCase
         $this->assertJsonStringEqualsJsonString($errorBody, $logEntry['context']['responseBody']);
     }
 
-    /**
-     * @expectedException \Commercetools\Core\Error\ApiException
-     */
     public function testBatchException()
     {
         $oauthMockBuilder = $this->getMockBuilder(Manager::class);
@@ -550,6 +546,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
         $clientMock->addBatchRequest($request1);
         $clientMock->addBatchRequest($request2);
 
+        $this->expectException(ApiException::class);
         $clientMock->executeBatch();
     }
 
@@ -661,7 +658,6 @@ class ClientTest extends \PHPUnit\Framework\TestCase
      * @param $returnCode
      * @param $exceptionClass
      * @param $returnBody
-     * @expectedException \Commercetools\Core\Error\ApiException
      */
     public function testExceptions($returnCode, $exceptionClass, $returnBody)
     {
@@ -678,6 +674,7 @@ class ClientTest extends \PHPUnit\Framework\TestCase
          */
         $request = $this->getMockForAbstractClass(AbstractQueryRequest::class, [$endpoint]);
 
+        $this->expectException(ApiException::class);
         try {
             $client->execute($request);
         } catch (\Exception $e) {

--- a/tests/unit/ConfigTest.php
+++ b/tests/unit/ConfigTest.php
@@ -6,6 +6,8 @@
 
 namespace Commercetools\Core;
 
+use Commercetools\Core\Error\InvalidArgumentException;
+
 class ConfigTest extends \PHPUnit\Framework\TestCase
 {
     protected function getConfig()
@@ -80,22 +82,18 @@ class ConfigTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals('https://api.europe-west1.gcp.commercetools.com', $config->getApiUrl());
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testUnknownEntry()
     {
         $config = new Config();
+        $this->expectException(InvalidArgumentException::class);
         $config->fromArray(['key' => 'value']);
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testInvalidConfig()
     {
         $config = new Config();
         $config->fromArray([]);
+        $this->expectException(InvalidArgumentException::class);
         $config->check();
     }
 
@@ -110,7 +108,6 @@ class ConfigTest extends \PHPUnit\Framework\TestCase
 
     /**
      * @dataProvider mandatoryConfig
-     * @expectedException \InvalidArgumentException
      */
     public function testNoClientIdSet($mandatoryField)
     {
@@ -118,6 +115,7 @@ class ConfigTest extends \PHPUnit\Framework\TestCase
         unset($testConfig[$mandatoryField]);
         $config = new Config();
         $config->fromArray($testConfig);
+        $this->expectException(InvalidArgumentException::class);
         $config->check();
     }
 

--- a/tests/unit/Model/Common/AttributeTest.php
+++ b/tests/unit/Model/Common/AttributeTest.php
@@ -14,10 +14,10 @@ class AttributeTest extends \PHPUnit\Framework\TestCase
     public function apiTypeProvider()
     {
         return [
-            'string' => ['string', ['name' => 'string', 'value' => 'bar']],
-            'int' => ['int', ['name' => 'int', 'value' => 1]],
-            'float' => ['float', ['name' => 'float', 'value' => 1.1]],
-            'bool' => ['bool', ['name' => 'bool', 'value' => true]],
+            'string' => ['string', ['name' => 'string', 'value' => 'bar'], 'assertIsString'],
+            'int' => ['int', ['name' => 'int', 'value' => 1], 'assertIsInt'],
+            'float' => ['float', ['name' => 'float', 'value' => 1.1], 'assertIsFloat'],
+            'bool' => ['bool', ['name' => 'bool', 'value' => true], 'assertIsBool'],
             'ltext' => [LocalizedString::class, ['name' => 'ltext', 'value' => ['en' => 'Foo']]],
             'enum' => [
                 Enum::class,
@@ -51,10 +51,10 @@ class AttributeTest extends \PHPUnit\Framework\TestCase
     public function valueTypeProvider()
     {
         return [
-            'string' => ['string', ['name' => 'value-string', 'value' => 'bar'], 'getValueAsString'],
-            'int' => ['int', ['name' => 'value-int', 'value' => 1], 'getValueAsNumber'],
-            'float' => ['float', ['name' => 'value-float', 'value' => 1.1], 'getValueAsNumber'],
-            'bool' => ['bool', ['name' => 'value-bool', 'value' => true], 'getValueAsBool'],
+            'string' => ['string', ['name' => 'value-string', 'value' => 'bar'], 'getValueAsString', null, 'assertIsString'],
+            'int' => ['int', ['name' => 'value-int', 'value' => 1], 'getValueAsNumber', null, 'assertIsInt'],
+            'float' => ['float', ['name' => 'value-float', 'value' => 1.1], 'getValueAsNumber', null, 'assertIsFloat'],
+            'bool' => ['bool', ['name' => 'value-bool', 'value' => true], 'getValueAsBool', null, 'assertIsBool'],
             'ltext' => [LocalizedString::class, ['name' => 'value-ltext', 'value' => ['en' => 'Foo']], 'getValueAsLocalizedString'],
             'enum' => [
                 Enum::class,
@@ -86,10 +86,10 @@ class AttributeTest extends \PHPUnit\Framework\TestCase
                 ],
                 'getValueAsNested'
             ],
-            'string-set' => [Set::class, ['name' => 'value-string-set', 'value' => ['value1', 'value2']], 'getValueAsStringSet', 'string'],
-            'int-set' => [Set::class, ['name' => 'value-int-set', 'value' => [1, 2]], 'getValueAsNumberSet', 'int'],
-            'float-set' => [Set::class, ['name' => 'value-float-set', 'value' => [1.1, 2.2]], 'getValueAsNumberSet', 'float'],
-            'bool-set' => [Set::class, ['name' => 'value-bool-set', 'value' => [true, false]], 'getValueAsBoolSet', 'bool'],
+            'string-set' => [Set::class, ['name' => 'value-string-set', 'value' => ['value1', 'value2']], 'getValueAsStringSet', 'string', 'assertIsString'],
+            'int-set' => [Set::class, ['name' => 'value-int-set', 'value' => [1, 2]], 'getValueAsNumberSet', 'int', 'assertIsInt'],
+            'float-set' => [Set::class, ['name' => 'value-float-set', 'value' => [1.1, 2.2]], 'getValueAsNumberSet', 'float', 'assertIsFloat'],
+            'bool-set' => [Set::class, ['name' => 'value-bool-set', 'value' => [true, false]], 'getValueAsBoolSet', 'bool', 'assertIsBool'],
             'ltext-set' => [Set::class, ['name' => 'value-ltext-set', 'value' => [['en' => 'Foo'], ['en' => 'Bar']]], 'getValueAsLocalizedStringSet', LocalizedString::class],
             'enum-set' => [Set::class, ['name' => 'value-enum-set', 'value' => [['key' => 'foo', 'label' => 'Foo'], ['key' => 'bar', 'label' => 'Bar']]], 'getValueAsEnumSet', Enum::class],
             'lenum-set' => [Set::class, ['name' => 'value-lenum-set', 'value' => [['key' => 'foo', 'label' => ['en' => 'Foo']], ['key' => 'bar', 'label' => ['en' => 'Bar']]]], 'getValueAsLocalizedEnumSet', LocalizedEnum::class],
@@ -115,23 +115,24 @@ class AttributeTest extends \PHPUnit\Framework\TestCase
      * @param string $type
      * @param array $data
      */
-    public function testFromArray($type, $data)
+    public function testFromArray($type, $data, $assertMethod = null)
     {
         $attribute = Attribute::fromArray($data);
 
         if (is_object($attribute->getValue())) {
             $this->assertInstanceOf($type, $attribute->getValue());
         } else {
-            $this->assertInternalType($type, $attribute->getValue());
+            $this->$assertMethod($attribute->getValue());
         }
     }
+
 
     /**
      * @dataProvider valueTypeProvider
      * @param string $type
      * @param array $data
      */
-    public function testGetValueAs($type, $data, $getter, $elementType = null)
+    public function testGetValueAs($type, $data, $getter, $elementType = null, $assertMethod = null)
     {
         $attribute = Attribute::fromArray($data);
 
@@ -139,14 +140,14 @@ class AttributeTest extends \PHPUnit\Framework\TestCase
         if (is_object($value)) {
             $this->assertInstanceOf($type, $value);
         } else {
-            $this->assertInternalType($type, $value);
+            $this->$assertMethod($value);
         }
         if (isset($elementType)) {
             $element = $value->current();
             if (is_object($element)) {
                 $this->assertInstanceOf($elementType, $element);
             } else {
-                $this->assertInternalType($elementType, $element);
+                $this->$assertMethod($element);
             }
         }
     }

--- a/tests/unit/Model/Common/CollectionTest.php
+++ b/tests/unit/Model/Common/CollectionTest.php
@@ -5,7 +5,7 @@
 
 namespace Commercetools\Core\Model\Common;
 
-use Commercetools\Core\Error\InvalidArgumentException;
+use InvalidArgumentException;
 use Commercetools\Core\Model\Product\ProductProjection;
 use Commercetools\Core\Model\Product\ProductProjectionCollection;
 
@@ -71,13 +71,11 @@ class CollectionTest extends \PHPUnit\Framework\TestCase
         $this->assertInstanceOf('\DateTime', $obj->getAt(0));
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testWrongType()
     {
         $obj = Collection::of();
         $obj->setType('\DateTime');
+        $this->expectException(InvalidArgumentException::class);
         $obj->add('test');
     }
 

--- a/tests/unit/Model/Common/ContextTest.php
+++ b/tests/unit/Model/Common/ContextTest.php
@@ -65,7 +65,7 @@ class ContextTest extends \PHPUnit\Framework\TestCase
     {
         $context = Context::of();
         $contextStr = serialize($context);
-        $this->assertInternalType('string', $contextStr);
+        $this->assertIsString($contextStr);
     }
 
     public function testSetLocaleWithoutIntl()

--- a/tests/unit/Model/Common/JsonObjectTest.php
+++ b/tests/unit/Model/Common/JsonObjectTest.php
@@ -6,6 +6,8 @@
 
 namespace Commercetools\Core\Model\Type;
 
+use InvalidArgumentException;
+use BadMethodCallException;
 use Commercetools\Core\Model\Common\DateTimeDecorator;
 use Commercetools\Core\Model\Common\JsonObject;
 use Commercetools\Core\Model\Common\LocalizedString;
@@ -98,29 +100,23 @@ class JsonObjectTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('newValue', $this->getObject()->setKey('newValue')->getKey());
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testWrongType()
     {
+        $this->expectException(InvalidArgumentException::class);
         $this->getObject()->setKey(1);
     }
 
-    /**
-     * @expectedException \BadMethodCallException
-     * @expectedExceptionMessage field
-     */
     public function testGetUnknownField()
     {
+        $this->expectException(BadMethodCallException::class);
+        $this->expectExceptionMessage('field');
         $this->getObject()->getUnknown();
     }
 
-    /**
-     * @expectedException \BadMethodCallException
-     * @expectedExceptionMessage field
-     */
     public function testSetUnknownField()
     {
+        $this->expectException(BadMethodCallException::class);
+        $this->expectExceptionMessage('unknown');
         $this->getObject()->setUnknown('unknown');
     }
 
@@ -136,12 +132,10 @@ class JsonObjectTest extends \PHPUnit\Framework\TestCase
         $this->assertSame(['key' => 'value'], $obj->toArray());
     }
 
-    /**
-     * @expectedException \BadMethodCallException
-     * @expectedExceptionMessage method
-     */
     public function testUnknownAction()
     {
+        $this->expectException(BadMethodCallException::class);
+        $this->expectExceptionMessage('method');
         $this->getObject()->hasKey();
     }
 
@@ -160,11 +154,9 @@ class JsonObjectTest extends \PHPUnit\Framework\TestCase
         $this->assertInstanceOf(JsonObject::class, JsonObject::of());
     }
 
-    /**
-     * @expectedException \InvalidArgumentException
-     */
     public function testSetNull()
     {
+        $this->expectException(InvalidArgumentException::class);
         $this->getObject()->setKey(null);
     }
 
@@ -194,7 +186,7 @@ class JsonObjectTest extends \PHPUnit\Framework\TestCase
     public function testGetReturnRaw()
     {
         $obj = $this->getMockBuilder(JsonObject::class)
-            ->setMethods(['initialize'])->setConstructorArgs( [['key' => 'value']])
+            ->setMethods(['initialize'])->setConstructorArgs([['key' => 'value']])
             ->getMock();
         $this->assertSame('value', $obj->get('key'));
     }

--- a/tests/unit/Model/Common/LocalizedStringTest.php
+++ b/tests/unit/Model/Common/LocalizedStringTest.php
@@ -39,11 +39,9 @@ class LocalizedStringTest extends \PHPUnit\Framework\TestCase
         return $context;
     }
 
-    /**
-     * @expectedException \Commercetools\Core\Error\InvalidArgumentException
-     */
     public function testGetUnknownLocale()
     {
+        $this->expectException(InvalidArgumentException::class);
         $this->getString()->get($this->getContext('de'));
     }
 

--- a/tests/unit/Model/CustomField/CustomFieldObjectTest.php
+++ b/tests/unit/Model/CustomField/CustomFieldObjectTest.php
@@ -125,11 +125,15 @@ class CustomFieldObjectTest extends \PHPUnit\Framework\TestCase
         return [
             'active' => [
                 ['active' => false],
-                'boolean'
+                'boolean',
+                null,
+                'assertIsBool',
             ],
             'description' => [
                 ['description' => 'my description'],
-                'string'
+                'string',
+                null,
+                'assertIsString',
             ],
             'name' => [
                 ['name' => ['en' => 'My awesome Shirt']],
@@ -137,7 +141,9 @@ class CustomFieldObjectTest extends \PHPUnit\Framework\TestCase
             ],
             'size' => [
                 ['size' => 48],
-                'integer'
+                'integer',
+                null,
+                'assertIsInt',
             ],
             'price' => [
                 ['price' => ['centAmount' => 100, 'currency' => 'EUR']],
@@ -158,7 +164,7 @@ class CustomFieldObjectTest extends \PHPUnit\Framework\TestCase
     /**
      * @dataProvider getCustomFields
      */
-    public function testData($dataArray, $type, $elementType = null)
+    public function testData($dataArray, $type, $elementType = null, $assertMethod = null)
     {
         $key = key($dataArray);
         $value = current($dataArray);
@@ -174,7 +180,7 @@ class CustomFieldObjectTest extends \PHPUnit\Framework\TestCase
         if (is_object($field)) {
             $this->assertInstanceOf($type, $field);
         } else {
-            $this->assertInternalType($type, $field);
+            $this->$assertMethod($field);
         }
         $this->assertJsonStringEqualsJsonString(json_encode($value), json_encode($field));
     }
@@ -193,10 +199,10 @@ class CustomFieldObjectTest extends \PHPUnit\Framework\TestCase
     public function valueTypeProvider()
     {
         return [
-            'string' => ['string', 'getFieldAsString', 'string'],
-            'int' => ['int', 'getFieldAsInteger', 'int'],
-            'float' => ['float', 'getFieldAsNumber', 'float'],
-            'bool' => ['bool', 'getFieldAsBool', 'bool'],
+            'string' => ['string', 'getFieldAsString', 'string', null, 'assertIsString'],
+            'int' => ['int', 'getFieldAsInteger', 'int', null, 'assertIsInt'],
+            'float' => ['float', 'getFieldAsNumber', 'float', null, 'assertIsFloat'],
+            'bool' => ['bool', 'getFieldAsBool', 'bool', null, 'assertIsBool'],
             'ltext' => [LocalizedString::class, 'getFieldAsLocalizedString', LocalizedStringType::NAME],
             'enum' => [Enum::class, 'getFieldAsEnum', EnumType::NAME],
             'lenum' => [LocalizedEnum::class, 'getFieldAsLocalizedEnum', LocalizedEnumType::NAME],
@@ -205,10 +211,10 @@ class CustomFieldObjectTest extends \PHPUnit\Framework\TestCase
             'time' => [TimeDecorator::class, 'getFieldAsTime', TimeType::NAME],
             'datetime' => [DateTimeDecorator::class, 'getFieldAsDateTime', DateTimeType::NAME],
             'reference' => [CategoryReference::class, 'getFieldAsReference', ReferenceType::NAME],
-            'string-set' => [Set::class, 'getFieldAsStringSet', 'string-' . SetType::NAME, 'string'],
-            'int-set' => [Set::class, 'getFieldAsIntegerSet', 'int-' . SetType::NAME, 'int'],
-            'float-set' => [Set::class, 'getFieldAsNumberSet', 'float-' . SetType::NAME, 'float'],
-            'bool-set' => [Set::class, 'getFieldAsBoolSet', 'bool-' . SetType::NAME, 'bool'],
+            'string-set' => [Set::class, 'getFieldAsStringSet', 'string-' . SetType::NAME, 'string', 'assertIsString'],
+            'int-set' => [Set::class, 'getFieldAsIntegerSet', 'int-' . SetType::NAME, 'int', 'assertIsInt'],
+            'float-set' => [Set::class, 'getFieldAsNumberSet', 'float-' . SetType::NAME, 'float', 'assertIsFloat'],
+            'bool-set' => [Set::class, 'getFieldAsBoolSet', 'bool-' . SetType::NAME, 'bool', 'assertIsBool'],
             'ltext-set' => [Set::class, 'getFieldAsLocalizedStringSet', LocalizedStringType::NAME . '-' . SetType::NAME, LocalizedString::class],
             'enum-set' => [Set::class, 'getFieldAsEnumSet', EnumType::NAME . '-' . SetType::NAME, Enum::class],
             'lenum-set' => [Set::class, 'getFieldAsLocalizedEnumSet', LocalizedEnumType::NAME . '-' . SetType::NAME, LocalizedEnum::class],
@@ -224,7 +230,7 @@ class CustomFieldObjectTest extends \PHPUnit\Framework\TestCase
      * @dataProvider valueTypeProvider
      * @param string $expectedType
      */
-    public function testFieldContainer($expectedType, $getter, $field, $expectedElementType = null)
+    public function testFieldContainer($expectedType, $getter, $field, $expectedElementType = null, $assertMethod = null)
     {
         $fields = [
             'string' => 'test',
@@ -260,16 +266,15 @@ class CustomFieldObjectTest extends \PHPUnit\Framework\TestCase
         if (is_object($value)) {
             $this->assertInstanceOf($expectedType, $value);
         } else {
-            $this->assertInternalType($expectedType, $value);
+            $this->$assertMethod($value);
         }
         if (isset($expectedElementType)) {
             $element = $value->current();
             if (is_object($element)) {
                 $this->assertInstanceOf($expectedElementType, $element);
             } else {
-                $this->assertInternalType($expectedElementType, $element);
+                $this->$assertMethod($element);
             }
         }
-
     }
 }

--- a/tests/unit/Model/Product/LocalizedSearchKeywordsTest.php
+++ b/tests/unit/Model/Product/LocalizedSearchKeywordsTest.php
@@ -5,7 +5,7 @@
 
 namespace Commercetools\Core\Model\Product;
 
-use Commercetools\Core\Error\InvalidArgumentException;
+use InvalidArgumentException;
 use Commercetools\Core\Model\Common\Context;
 
 class LocalizedSearchKeywordsTest extends \PHPUnit\Framework\TestCase
@@ -27,11 +27,9 @@ class LocalizedSearchKeywordsTest extends \PHPUnit\Framework\TestCase
         $this->assertSame('', (string)$collection->en);
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testGetNoLocale()
     {
+        $this->expectException(InvalidArgumentException::class);
         $collection = LocalizedSearchKeywords::of();
         $collection->get();
     }

--- a/tests/unit/Model/ProductType/AttributeTypeTest.php
+++ b/tests/unit/Model/ProductType/AttributeTypeTest.php
@@ -5,6 +5,7 @@
 
 namespace Commercetools\Core\Model\ProductType;
 
+use BadMethodCallException;
 use Commercetools\Core\Model\Common\EnumCollection;
 use Commercetools\Core\Model\Common\JsonObject;
 use Commercetools\Core\Model\Common\LocalizedEnumCollection;
@@ -33,14 +34,12 @@ class AttributeTypeTest extends \PHPUnit\Framework\TestCase
         );
     }
 
-    /**
-     * @expectedException \BadMethodCallException
-     */
     public function testTypeUnset()
     {
         $type = AttributeType::fromArray([
             'name' => 'text'
         ]);
+        $this->expectException(BadMethodCallException::class);
         $type->getValues();
     }
 }

--- a/tests/unit/Request/AbstractApiRequestTest.php
+++ b/tests/unit/Request/AbstractApiRequestTest.php
@@ -97,12 +97,10 @@ class AbstractApiRequestTest extends \PHPUnit\Framework\TestCase
         );
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testNoParamKey()
     {
         $request = $this->getRequest(static::ABSTRACT_API_REQUEST);
+        $this->expectException(\InvalidArgumentException::class);
         $request->addParam('', '');
     }
 

--- a/tests/unit/Request/AbstractUpdateByKeyRequestTest.php
+++ b/tests/unit/Request/AbstractUpdateByKeyRequestTest.php
@@ -6,6 +6,7 @@
 
 namespace Commercetools\Core\Request;
 
+use Commercetools\Core\Error\UpdateActionLimitException;
 use Commercetools\Core\Response\ResourceResponse;
 use Monolog\Handler\TestHandler;
 use Monolog\Logger;
@@ -120,12 +121,10 @@ class AbstractUpdateByKeyRequestTest extends \PHPUnit\Framework\TestCase
         $this->assertCount(AbstractUpdateRequest::ACTION_MAX_LIMIT, $request->getActions());
     }
 
-    /**
-     * @expectedException \Commercetools\Core\Error\UpdateActionLimitException
-     */
     public function testLogLimitException()
     {
         $request = $this->getUpdateRequest();
+        $this->expectException(UpdateActionLimitException::class);
         for ($i = 0; $i <= (AbstractUpdateRequest::ACTION_MAX_LIMIT); $i++) {
             $request->addActionAsArray(['key' => 'value']);
         }

--- a/tests/unit/Request/InStores/InStoreRequestDecoratorTest.php
+++ b/tests/unit/Request/InStores/InStoreRequestDecoratorTest.php
@@ -6,9 +6,7 @@
 namespace Commercetools\Core\Request\InStores;
 
 use Commercetools\Core\Error\InvalidArgumentException;
-use Commercetools\Core\Request\AbstractByIdGetRequest;
 use Commercetools\Core\Request\Carts\CartByIdGetRequest;
-use Commercetools\Core\Request\Customers\CustomerByIdGetRequest;
 use Commercetools\Core\Request\Orders\OrderByIdGetRequest;
 use Commercetools\Core\Request\Project\ProjectGetRequest;
 use Commercetools\Core\RequestTestCase;
@@ -35,12 +33,10 @@ class InStoreRequestDecoratorTest extends RequestTestCase
         $this->assertSame('in-store/key=store-key/orders/order-id', (string)$decoratedRequest->getUri());
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testInvalidRequest()
     {
         $request = ProjectGetRequest::of();
+        $this->expectException(InvalidArgumentException::class);
         InStoreRequestDecorator::ofStoreKeyAndRequest('store-key', $request);
     }
 }

--- a/tests/unit/Request/Products/ProductProjectionBySlugGetRequestTest.php
+++ b/tests/unit/Request/Products/ProductProjectionBySlugGetRequestTest.php
@@ -30,11 +30,9 @@ class ProductProjectionBySlugGetRequestTest extends RequestTestCase
         return ['slug', $this->getContext()];
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testNoLanguages()
     {
+        $this->expectException(InvalidArgumentException::class);
         ProductProjectionBySlugGetRequest::ofSlugAndContext('slug', new Context());
     }
 
@@ -106,19 +104,15 @@ class ProductProjectionBySlugGetRequestTest extends RequestTestCase
         );
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testHttpRequestPathSingleLanguageTypeContext()
     {
+        $this->expectException(InvalidArgumentException::class);
         $request = ProductProjectionBySlugGetRequest::ofSlugAndLanguage('slug', $this->getContext());
     }
 
-    /**
-     * @expectedException InvalidArgumentException
-     */
     public function testHttpRequestPathSingleLanguageTypeArray()
     {
+        $this->expectException(InvalidArgumentException::class);
         $request = ProductProjectionBySlugGetRequest::ofSlugAndLanguage('slug', ['de']);
     }
 

--- a/tests/unit/Request/Products/ProductProjectionSearchRequestTest.php
+++ b/tests/unit/Request/Products/ProductProjectionSearchRequestTest.php
@@ -27,7 +27,7 @@ class ProductProjectionSearchRequestTest extends RequestTestCase
         $httpRequest = $request->httpRequest();
 
         $this->assertSame('product-projections/search', (string)$httpRequest->getUri());
-        $this->assertContains('fuzzy=true', (string)$httpRequest->getBody());
+        $this->assertStringContainsString('fuzzy=true', (string)$httpRequest->getBody());
     }
 
     public function testMarkMatchingVariant()
@@ -94,7 +94,7 @@ class ProductProjectionSearchRequestTest extends RequestTestCase
         $httpRequest = $request->httpRequest();
 
         $this->assertSame('product-projections/search', (string)$httpRequest->getUri());
-        $this->assertContains($expected, (string)$httpRequest->getBody());
+        $this->assertStringContainsString($expected, (string)$httpRequest->getBody());
     }
 
     public function testMapResult()
@@ -126,7 +126,7 @@ class ProductProjectionSearchRequestTest extends RequestTestCase
         $httpRequest = $request->httpRequest();
 
         $this->assertSame('product-projections/search', (string)$httpRequest->getUri());
-        $this->assertContains('filter=key%3A%22value%22', (string)$httpRequest->getBody());
+        $this->assertStringContainsString('filter=key%3A%22value%22', (string)$httpRequest->getBody());
     }
 
     public function testAddMultiFilterString()
@@ -140,7 +140,7 @@ class ProductProjectionSearchRequestTest extends RequestTestCase
         $httpRequest = $request->httpRequest();
 
         $this->assertSame('product-projections/search', (string)$httpRequest->getUri());
-        $this->assertContains('filter=foo%3A%22bar%22&filter=key%3A%22value%22', (string)$httpRequest->getBody());
+        $this->assertStringContainsString('filter=foo%3A%22bar%22&filter=key%3A%22value%22', (string)$httpRequest->getBody());
     }
 
     public function testAddFilterInt()
@@ -153,7 +153,7 @@ class ProductProjectionSearchRequestTest extends RequestTestCase
         $httpRequest = $request->httpRequest();
 
         $this->assertSame('product-projections/search', (string)$httpRequest->getUri());
-        $this->assertContains('filter=key%3A10', (string)$httpRequest->getBody());
+        $this->assertStringContainsString('filter=key%3A10', (string)$httpRequest->getBody());
     }
 
     public function testAddFilterArray()
@@ -166,7 +166,7 @@ class ProductProjectionSearchRequestTest extends RequestTestCase
         $httpRequest = $request->httpRequest();
 
         $this->assertSame('product-projections/search', (string)$httpRequest->getUri());
-        $this->assertContains('filter=key%3A10%2C20%2C30', (string)$httpRequest->getBody());
+        $this->assertStringContainsString('filter=key%3A10%2C20%2C30', (string)$httpRequest->getBody());
     }
 
     public function testAddFilterQuery()
@@ -179,7 +179,7 @@ class ProductProjectionSearchRequestTest extends RequestTestCase
         $httpRequest = $request->httpRequest();
 
         $this->assertSame('product-projections/search', (string)$httpRequest->getUri());
-        $this->assertContains('filter.query=key%3A%22value%22', (string)$httpRequest->getBody());
+        $this->assertStringContainsString('filter.query=key%3A%22value%22', (string)$httpRequest->getBody());
     }
 
     public function testAddFilterQueryFacet()
@@ -193,7 +193,7 @@ class ProductProjectionSearchRequestTest extends RequestTestCase
         $httpRequest = $request->httpRequest();
 
         $this->assertSame('product-projections/search', (string)$httpRequest->getUri());
-        $this->assertContains('facet=key%3A%22value%22&filter.query=key%3A%22value%22', (string)$httpRequest->getBody());
+        $this->assertStringContainsString('facet=key%3A%22value%22&filter.query=key%3A%22value%22', (string)$httpRequest->getBody());
     }
 
     public function testAddMultiFilterQuery()
@@ -207,7 +207,7 @@ class ProductProjectionSearchRequestTest extends RequestTestCase
         $httpRequest = $request->httpRequest();
 
         $this->assertSame('product-projections/search', (string)$httpRequest->getUri());
-        $this->assertContains(
+        $this->assertStringContainsString(
             'filter.query=foo%3A%22bar%22&filter.query=key%3A%22value%22',
             (string)$httpRequest->getBody()
         );
@@ -223,7 +223,7 @@ class ProductProjectionSearchRequestTest extends RequestTestCase
         $httpRequest = $request->httpRequest();
 
         $this->assertSame('product-projections/search', (string)$httpRequest->getUri());
-        $this->assertContains('filter.facets=key%3A%22value%22', (string)$httpRequest->getBody());
+        $this->assertStringContainsString('filter.facets=key%3A%22value%22', (string)$httpRequest->getBody());
     }
 
     public function testAddMultiFilterFacets()
@@ -237,7 +237,7 @@ class ProductProjectionSearchRequestTest extends RequestTestCase
         $httpRequest = $request->httpRequest();
 
         $this->assertSame('product-projections/search', (string)$httpRequest->getUri());
-        $this->assertContains(
+        $this->assertStringContainsString(
             'filter.facets=foo%3A%22bar%22&filter.facets=key%3A%22value%22',
             (string)$httpRequest->getBody()
         );
@@ -253,7 +253,7 @@ class ProductProjectionSearchRequestTest extends RequestTestCase
         $httpRequest = $request->httpRequest();
 
         $this->assertSame('product-projections/search', (string)$httpRequest->getUri());
-        $this->assertContains('facet=key%3A%22value%22', (string)$httpRequest->getBody());
+        $this->assertStringContainsString('facet=key%3A%22value%22', (string)$httpRequest->getBody());
     }
 
     public function testAddMultiFacet()
@@ -267,7 +267,7 @@ class ProductProjectionSearchRequestTest extends RequestTestCase
         $httpRequest = $request->httpRequest();
 
         $this->assertSame('product-projections/search', (string)$httpRequest->getUri());
-        $this->assertContains('facet=foo%3A%22bar%22&facet=key%3A%22value%22', (string)$httpRequest->getBody());
+        $this->assertStringContainsString('facet=foo%3A%22bar%22&facet=key%3A%22value%22', (string)$httpRequest->getBody());
     }
 
     public function testHttpRequestMethod()

--- a/tests/unit/Request/Products/ProductsSuggestRequestTest.php
+++ b/tests/unit/Request/Products/ProductsSuggestRequestTest.php
@@ -73,7 +73,7 @@ class ProductsSuggestRequestTest extends RequestTestCase
         $httpRequest = $request->httpRequest();
 
         $this->assertStringStartsWith('product-projections/suggest', (string)$httpRequest->getUri());
-        $this->assertContains($expected, (string)$httpRequest->getUri());
+        $this->assertStringContainsString($expected, (string)$httpRequest->getUri());
     }
 
     public function testFuzzyKeyword()
@@ -86,9 +86,9 @@ class ProductsSuggestRequestTest extends RequestTestCase
         $httpRequest = $request->httpRequest();
 
         $this->assertStringStartsWith('product-projections/suggest', (string)$httpRequest->getUri());
-        $this->assertContains('fuzzy=true&searchKeywords.en=test', (string)$httpRequest->getUri());
+        $this->assertStringContainsString('fuzzy=true&searchKeywords.en=test', (string)$httpRequest->getUri());
     }
-    
+
     public function testAddKeyword()
     {
         $request = ProductsSuggestRequest::of();

--- a/tests/unit/Response/AbstractApiResponseTest.php
+++ b/tests/unit/Response/AbstractApiResponseTest.php
@@ -19,6 +19,7 @@ use Commercetools\Core\Client\Adapter\Guzzle6Adapter;
 use Commercetools\Core\Client\HttpMethod;
 use Commercetools\Core\Error\ApiException;
 use Commercetools\Core\Request\AbstractApiRequest;
+use BadMethodCallException;
 
 /**
  * Class AbstractApiResponseTest
@@ -154,21 +155,17 @@ class AbstractApiResponseTest extends \PHPUnit\Framework\TestCase
         $this->assertNull($response->toObject());
     }
 
-    /**
-     * @expectedException \BadMethodCallException
-     */
     public function testThenFail()
     {
         $response = $this->getResponse('{"key":"value"}');
+        $this->expectException(BadMethodCallException::class);
         $response->then();
     }
 
-    /**
-     * @expectedException \BadMethodCallException
-     */
     public function testWaitFail()
     {
         $response = $this->getResponse('{"key":"value"}');
+        $this->expectException(BadMethodCallException::class);
         $response->wait();
     }
 


### PR DESCRIPTION
1. code and add tests that cover the created code. Your code should be warning-free.
   * [ ] tests existing
1. stick to PSR-2 and and don't reformat existing code.
   * [ ] code style check succesful
