### PR TITLE
Update JsonObject.php

### DIFF
--- a/src/Core/Model/Common/JsonObject.php
+++ b/src/Core/Model/Common/JsonObject.php
@@ -175,7 +175,7 @@ class JsonObject extends AbstractJsonDeserializeObject implements \JsonSerializa
              * @var JsonDeserializeInterface $type
              */
             $value = $this->getRaw($field, null);
-            if (!is_null($value)) {
+            if (!is_null($value) && is_array($value)) {
                 $value = $type::fromArray($value, $this->getContextCallback());
             }
         } else {


### PR DESCRIPTION
To avoid the error when the parameter is not an array.

1. code and add tests that cover the created code. Your code should be warning-free.
   * [x] tests existing
1. stick to PSR-2 and and don't reformat existing code.
   * [x] code style check succesful
