### PR TITLE
Fix wrong action limit in error message (before: 400, after: 500)

### DIFF
--- a/src/Core/Request/AbstractUpdateRequest.php
+++ b/src/Core/Request/AbstractUpdateRequest.php
@@ -126,7 +126,7 @@ abstract class AbstractUpdateRequest extends AbstractApiRequest
             $message = sprintf(
                 Message::UPDATE_ACTION_LIMIT,
                 $this->getPath(),
-                static::ACTION_WARNING_TRESHOLD
+                static::ACTION_MAX_LIMIT
             );
             throw new UpdateActionLimitException($message);
         }


### PR DESCRIPTION
Currently, the error message for the action limit displays "400" even though the limit is 500. The wrong constant was used for the message.