### PR TITLE
test(unit): test php 8.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,7 @@ jobs:
           - "7.3"
           - "7.4"
           - "8.0"
+          - "8.1"
 
         dependencies:
           - lowest

--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,7 @@
   },
   "require-dev": {
     "guzzlehttp/guzzle": "^7.0 || ^6.0",
-    "phpunit/phpunit": "^9.0",
+    "phpunit/phpunit": "9.5.10",
     "phpspec/prophecy-phpunit": "^2.0",
     "symplify/easy-coding-standard": "10.0.2",
     "doctrine/cache": "^1.6 || ^2.0",

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
     "guzzlehttp/guzzle": "^7.0 || ^6.0",
     "phpunit/phpunit": "^9.0",
     "phpspec/prophecy-phpunit": "^2.0",
-    "symplify/easy-coding-standard-prefixed": "8.3.48 || 9.2.23",
+    "symplify/easy-coding-standard": "10.0.2",
     "doctrine/cache": "^1.6 || ^2.0",
     "monolog/monolog": "^1.12 || ^2.0",
     "symfony/yaml": "^4.0 || ^3.4.38 || ^5.0",

--- a/src/Core/Helper/Annotate/AnnotationGenerator.php
+++ b/src/Core/Helper/Annotate/AnnotationGenerator.php
@@ -92,7 +92,7 @@ class AnnotationGenerator
         $jsonObjects = [];
         foreach ($phpFiles as $phpFile) {
             $class = $this->getClassName($phpFile->getRealPath());
-            if (strpos($class, 'Core\\Helper') > 0) {
+            if ($class != null && strpos($class, 'Core\\Helper') > 0) {
                 continue;
             }
 
@@ -112,7 +112,7 @@ class AnnotationGenerator
         $collectionObjects = [];
         foreach ($phpFiles as $phpFile) {
             $class = $this->getClassName($phpFile->getRealPath());
-            if (strpos($class, 'Core\\Helper') > 0) {
+            if ($class != null && strpos($class, 'Core\\Helper') > 0) {
                 continue;
             }
 
@@ -132,7 +132,7 @@ class AnnotationGenerator
         $requestObjects = [];
         foreach ($phpFiles as $phpFile) {
             $class = $this->getClassName($phpFile->getRealPath());
-            if (strpos($class, 'Core\\Helper') > 0) {
+            if ($class != null && strpos($class, 'Core\\Helper') > 0) {
                 continue;
             }
 
@@ -152,7 +152,7 @@ class AnnotationGenerator
         $requestObjects = [];
         foreach ($phpFiles as $phpFile) {
             $class = $this->getClassName($phpFile->getRealPath());
-            if (strpos($class, 'Core\\Helper') > 0) {
+            if ($class != null && strpos($class, 'Core\\Helper') > 0) {
                 continue;
             }
 
@@ -164,10 +164,10 @@ class AnnotationGenerator
                 ) {
                     $namespaceParts = explode("\\", $class->getNamespaceName());
                     $domain = $namespaceParts[count($namespaceParts) - 1];
-                    if (strpos($class, 'ProductProjection') > 0) {
+                    if ($class != null && strpos($class, 'ProductProjection') > 0) {
                         $domain = 'ProductProjections';
                     }
-                    if (strpos($class, 'ProductsSuggest') > 0) {
+                    if ($class != null && strpos($class, 'ProductsSuggest') > 0) {
                         $domain = 'ProductProjections';
                     }
                     $requestObjects[$domain][] = $class->getName();
@@ -183,7 +183,7 @@ class AnnotationGenerator
         $actions = [];
         foreach ($phpFiles as $phpFile) {
             $class = $this->getClassName($phpFile->getRealPath());
-            if (strpos($class, 'Core\\Helper') > 0) {
+            if ($class != null && strpos($class, 'Core\\Helper') > 0) {
                 continue;
             }
 

--- a/src/Core/Model/Common/AbstractJsonDeserializeObject.php
+++ b/src/Core/Model/Common/AbstractJsonDeserializeObject.php
@@ -173,6 +173,7 @@ abstract class AbstractJsonDeserializeObject implements JsonDeserializeInterface
         return isset($this->rawData[$field])? $this->rawData[$field]: $default;
     }
 
+    #[\ReturnTypeWillChange]
     /**
      * (PHP 5 &gt;= 5.4.0)<br/>
      * Specify data which should be serialized to JSON

--- a/src/Core/Model/Common/Collection.php
+++ b/src/Core/Model/Common/Collection.php
@@ -225,6 +225,7 @@ class Collection extends AbstractJsonDeserializeObject implements \Iterator, \Js
         return $this;
     }
 
+    #[\ReturnTypeWillChange]
     /**
      * (PHP 5 &gt;= 5.1.0)<br/>
      * Count elements of an object
@@ -244,6 +245,7 @@ class Collection extends AbstractJsonDeserializeObject implements \Iterator, \Js
     }
 
 
+    #[\ReturnTypeWillChange]
     /**
      * (PHP 5 &gt;= 5.0.0)<br/>
      * Return the current element
@@ -258,6 +260,7 @@ class Collection extends AbstractJsonDeserializeObject implements \Iterator, \Js
         return null;
     }
 
+    #[\ReturnTypeWillChange]
     /**
      * (PHP 5 &gt;= 5.0.0)<br/>
      * Move forward to next element
@@ -269,6 +272,7 @@ class Collection extends AbstractJsonDeserializeObject implements \Iterator, \Js
         $this->pos++;
     }
 
+    #[\ReturnTypeWillChange]
     /**
      * (PHP 5 &gt;= 5.0.0)<br/>
      * Return the key of the current element
@@ -283,6 +287,7 @@ class Collection extends AbstractJsonDeserializeObject implements \Iterator, \Js
         return null;
     }
 
+    #[\ReturnTypeWillChange]
     /**
      * (PHP 5 &gt;= 5.0.0)<br/>
      * Checks if current position is valid
@@ -298,6 +303,7 @@ class Collection extends AbstractJsonDeserializeObject implements \Iterator, \Js
         return false;
     }
 
+    #[\ReturnTypeWillChange]
     /**
      * (PHP 5 &gt;= 5.0.0)<br/>
      * Rewind the Iterator to the first element
@@ -309,6 +315,7 @@ class Collection extends AbstractJsonDeserializeObject implements \Iterator, \Js
         $this->pos = 0;
     }
 
+    #[\ReturnTypeWillChange]
     /**
      * (PHP 5 &gt;= 5.0.0)<br/>
      * Whether a offset exists
@@ -326,6 +333,7 @@ class Collection extends AbstractJsonDeserializeObject implements \Iterator, \Js
         return isset($this->rawData[$offset]) || isset($this->typeData[$offset]);
     }
 
+    #[\ReturnTypeWillChange]
     /**
      * (PHP 5 &gt;= 5.0.0)<br/>
      * Offset to retrieve
@@ -340,6 +348,7 @@ class Collection extends AbstractJsonDeserializeObject implements \Iterator, \Js
         return $this->getAt($offset);
     }
 
+    #[\ReturnTypeWillChange]
     /**
      * (PHP 5 &gt;= 5.0.0)<br/>
      * Offset to set
@@ -357,6 +366,7 @@ class Collection extends AbstractJsonDeserializeObject implements \Iterator, \Js
         $this->setAt($offset, $value);
     }
 
+    #[\ReturnTypeWillChange]
     /**
      * (PHP 5 &gt;= 5.0.0)<br/>
      * Offset to unset

--- a/src/Core/Model/Common/Context.php
+++ b/src/Core/Model/Common/Context.php
@@ -198,6 +198,7 @@ class Context implements \ArrayAccess
         return new static();
     }
 
+    #[\ReturnTypeWillChange]
     /**
      * @inheritDoc
      */
@@ -206,6 +207,7 @@ class Context implements \ArrayAccess
         return isset($this->$offset);
     }
 
+    #[\ReturnTypeWillChange]
     /**
      * @inheritDoc
      */
@@ -219,6 +221,7 @@ class Context implements \ArrayAccess
         return null;
     }
 
+    #[\ReturnTypeWillChange]
     /**
      * @inheritDoc
      */
@@ -231,6 +234,7 @@ class Context implements \ArrayAccess
         }
     }
 
+    #[\ReturnTypeWillChange]
     /**
      * @inheritDoc
      */

--- a/src/Core/Model/Common/DateTimeDecorator.php
+++ b/src/Core/Model/Common/DateTimeDecorator.php
@@ -56,6 +56,7 @@ class DateTimeDecorator implements \JsonSerializable
         return $dateTime;
     }
 
+    #[\ReturnTypeWillChange]
     /**
      * @return string
      */

--- a/src/Core/Model/Common/LocalizedString.php
+++ b/src/Core/Model/Common/LocalizedString.php
@@ -136,6 +136,7 @@ class LocalizedString implements \JsonSerializable, JsonDeserializeInterface
         return $data;
     }
 
+    #[\ReturnTypeWillChange]
     /**
      * @return array
      */

--- a/src/Core/Response/PagedQueryResponse.php
+++ b/src/Core/Response/PagedQueryResponse.php
@@ -84,6 +84,7 @@ class PagedQueryResponse extends AbstractApiResponse implements \IteratorAggrega
     }
 
 
+    #[\ReturnTypeWillChange]
     /**
      * (PHP 5 &gt;= 5.0.0)<br/>
      * Retrieve an external iterator
@@ -97,6 +98,7 @@ class PagedQueryResponse extends AbstractApiResponse implements \IteratorAggrega
         return new \ArrayIterator($this->results);
     }
 
+    #[\ReturnTypeWillChange]
     /**
      * (PHP 5 &gt;= 5.0.0)<br/>
      * Whether a offset exists
@@ -115,6 +117,7 @@ class PagedQueryResponse extends AbstractApiResponse implements \IteratorAggrega
         return isset($results[$offset]);
     }
 
+    #[\ReturnTypeWillChange]
     /**
      * (PHP 5 &gt;= 5.0.0)<br/>
      * Offset to retrieve
@@ -130,6 +133,7 @@ class PagedQueryResponse extends AbstractApiResponse implements \IteratorAggrega
         return $results[$offset];
     }
 
+    #[\ReturnTypeWillChange]
     /**
      * (PHP 5 &gt;= 5.0.0)<br/>
      * Offset to set
@@ -152,6 +156,7 @@ class PagedQueryResponse extends AbstractApiResponse implements \IteratorAggrega
         }
     }
 
+    #[\ReturnTypeWillChange]
     /**
      * (PHP 5 &gt;= 5.0.0)<br/>
      * Offset to unset

--- a/tests/unit/Builder/Update/GenericActionBuilderTest.php
+++ b/tests/unit/Builder/Update/GenericActionBuilderTest.php
@@ -33,7 +33,7 @@ class GenericActionBuilderTest extends TestCase
         $actions = [];
         foreach ($phpFiles as $phpFile) {
             $class = $this->getClassName($phpFile->getRealPath());
-            if (strpos($class, 'Core\\Helper') > 0) {
+            if ($class != null && strpos($class, 'Core\\Helper') > 0) {
                 continue;
             }
 

--- a/tests/unit/Model/RamlModelTest.php
+++ b/tests/unit/Model/RamlModelTest.php
@@ -476,7 +476,7 @@ class RamlModelTest extends AbstractModelTest
         $modelClasses = [];
         foreach ($phpFiles as $phpFile) {
             $class = $this->getFileClassName($phpFile->getRealPath());
-            if (strpos($class, 'Core\\Helper') > 0) {
+            if ($class != null && strpos($class, 'Core\\Helper') > 0) {
                 continue;
             }
 

--- a/tools/php_cs_fixer/php-cs-fixer-psr2.php
+++ b/tools/php_cs_fixer/php-cs-fixer-psr2.php
@@ -56,7 +56,7 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     $services->set(MethodArgumentSpaceFixer::class)
         ->call('configure', [[
-            'ensure_fully_multiline' => true,
+            'on_multiline' => 'ensure_fully_multiline',
         ]]);
 
     $services->set(NoBreakCommentFixer::class);
@@ -86,5 +86,8 @@ return static function (ContainerConfigurator $containerConfigurator): void {
 
     $services->set(SwitchCaseSpaceFixer::class);
 
-    $services->set(VisibilityRequiredFixer::class);
+    $services->set(VisibilityRequiredFixer::class)
+        ->call('configure', [[
+            'elements' => ['property', 'method']
+        ]]);
 };


### PR DESCRIPTION
fix deprecation warnings
fix ecs for php 8.1

1. code and add tests that cover the created code. Your code should be warning-free.
   * [ ] tests existing
1. stick to PSR-2 and and don't reformat existing code.
   * [ ] code style check succesful
