### PR TITLE
support new endpoint: ProductSelection

### DIFF
--- a/src/Core/Builder/Request/ProductSelectionRequestBuilder.php
+++ b/src/Core/Builder/Request/ProductSelectionRequestBuilder.php
@@ -1,0 +1,138 @@
+<?php
+// phpcs:disable Generic.Files.LineLength
+namespace Commercetools\Core\Builder\Request;
+
+use Commercetools\Core\Request\ProductSelections\ProductSelectionByIdGetRequest;
+use Commercetools\Core\Request\ProductSelections\ProductSelectionByIdProductsGetRequest;
+use Commercetools\Core\Request\ProductSelections\ProductSelectionByKeyGetRequest;
+use Commercetools\Core\Request\ProductSelections\ProductSelectionByKeyProductsGetRequest;
+use Commercetools\Core\Request\ProductSelections\ProductSelectionCreateRequest;
+use Commercetools\Core\Model\ProductSelection\ProductSelectionDraft;
+use Commercetools\Core\Request\ProductSelections\ProductSelectionDeleteByKeyRequest;
+use Commercetools\Core\Model\ProductSelection\ProductSelection;
+use Commercetools\Core\Request\ProductSelections\ProductSelectionDeleteRequest;
+use Commercetools\Core\Request\ProductSelections\ProductSelectionQueryRequest;
+use Commercetools\Core\Request\ProductSelections\ProductSelectionUpdateByKeyRequest;
+use Commercetools\Core\Request\ProductSelections\ProductSelectionUpdateRequest;
+
+class ProductSelectionRequestBuilder
+{
+
+    /**
+     * @link https://docs.commercetools.com/http-api-projects-productSelections.html#get-a-productselection-by-id
+     * @param string $id
+     * @return ProductSelectionByIdGetRequest
+     */
+    public function getById($id)
+    {
+        $request = ProductSelectionByIdGetRequest::ofId($id);
+        return $request;
+    }
+
+    /**
+     *
+     * @param string $idProducts
+     * @return ProductSelectionByIdProductsGetRequest
+     */
+    public function getByIdProducts($idProducts)
+    {
+        $request = ProductSelectionByIdProductsGetRequest::ofIdProducts($idProducts);
+        return $request;
+    }
+
+    /**
+     * @link https://docs.commercetools.com/http-api-projects-productSelections.html#get-a-productselection-by-key
+     * @param string $key
+     * @return ProductSelectionByKeyGetRequest
+     */
+    public function getByKey($key)
+    {
+        $request = ProductSelectionByKeyGetRequest::ofKey($key);
+        return $request;
+    }
+
+    /**
+     *
+     * @param string $keyProducts
+     * @return ProductSelectionByKeyProductsGetRequest
+     */
+    public function getByKeyProducts($keyProducts)
+    {
+        $request = ProductSelectionByKeyProductsGetRequest::ofKeyProducts($keyProducts);
+        return $request;
+    }
+
+    /**
+     * @link https://docs.commercetools.com/http-api-projects-productSelections.html#create-a-productselection
+     * @param ProductSelectionDraft $productSelection
+     * @return ProductSelectionCreateRequest
+     */
+    public function create(ProductSelectionDraft $productSelection)
+    {
+        $request = ProductSelectionCreateRequest::ofDraft($productSelection);
+        return $request;
+    }
+
+    /**
+     * @link https://docs.commercetools.com/http-api-projects-productSelections.html#delete-productselection-by-key
+     * @param ProductSelection $productSelection
+     * @return ProductSelectionDeleteByKeyRequest
+     */
+    public function deleteByKey(ProductSelection $productSelection)
+    {
+        $request = ProductSelectionDeleteByKeyRequest::ofKeyAndVersion($productSelection->getKey(), $productSelection->getVersion());
+        return $request;
+    }
+
+    /**
+     * @link https://docs.commercetools.com/http-api-projects-product=selection.html#delete-productselection-by-id
+     * @param ProductSelection $productSelection
+     * @return ProductSelectionDeleteRequest
+     */
+    public function delete(ProductSelection $productSelection)
+    {
+        $request = ProductSelectionDeleteRequest::ofIdAndVersion($productSelection->getId(), $productSelection->getVersion());
+        return $request;
+    }
+
+    /**
+     * @link https://docs.commercetools.com/http-api-projects-productSelections.html#query-producttypes
+     *
+     * @return ProductSelectionQueryRequest
+     */
+    public function query()
+    {
+        $request = ProductSelectionQueryRequest::of();
+        return $request;
+    }
+
+    /**
+     *
+     * @param ProductSelection $productSelection
+     * @return ProductSelectionUpdateByKeyRequest
+     */
+    public function updateByKey(ProductSelection $productSelection)
+    {
+        $request = ProductSelectionUpdateByKeyRequest::ofKeyAndVersion($productSelection->getKey(), $productSelection->getVersion());
+        return $request;
+    }
+
+    /**
+     * @link https://docs.commercetools.com/http-api-projects-product-selections.html#update-productselection
+     * @param ProductSelection $productSelection
+     * @return ProductSelectionUpdateRequest
+     */
+    public function update(ProductSelection $productSelection)
+    {
+        $request = ProductSelectionUpdateRequest::ofIdAndVersion($productSelection->getId(), $productSelection->getVersion());
+        return $request;
+    }
+
+    /**
+     * @return ProductSelectionRequestBuilder
+     */
+    public function of()
+    {
+        return new self();
+    }
+}

--- a/src/Core/Builder/Request/RequestBuilder.php
+++ b/src/Core/Builder/Request/RequestBuilder.php
@@ -160,6 +160,14 @@ class RequestBuilder
     }
 
     /**
+     * @return ProductSelectionRequestBuilder
+     */
+    public function productSelections()
+    {
+        return new ProductSelectionRequestBuilder();
+    }
+
+    /**
      * @return ProductTypeRequestBuilder
      */
     public function productTypes()

--- a/src/Core/Builder/Update/ActionBuilder.php
+++ b/src/Core/Builder/Update/ActionBuilder.php
@@ -125,6 +125,14 @@ class ActionBuilder
     }
 
     /**
+     * @return ProductSelectionsActionBuilder
+     */
+    public function productSelections()
+    {
+        return new ProductSelectionsActionBuilder();
+    }
+
+    /**
      * @return ProductTypesActionBuilder
      */
     public function productTypes()

--- a/src/Core/Builder/Update/ProductSelectionsActionBuilder.php
+++ b/src/Core/Builder/Update/ProductSelectionsActionBuilder.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace Commercetools\Core\Builder\Update;
+
+use Commercetools\Core\Error\InvalidArgumentException;
+use Commercetools\Core\Request\AbstractAction;
+use Commercetools\Core\Request\ProductSelections\Command\ProductSelectionAddProductAction;
+use Commercetools\Core\Request\ProductSelections\Command\ProductSelectionChangeNameAction;
+use Commercetools\Core\Request\ProductSelections\Command\ProductSelectionRemoveProductAction;
+use Commercetools\Core\Request\ProductSelections\Command\ProductSelectionSetKeyAction;
+
+class ProductSelectionsActionBuilder
+{
+    private $actions = [];
+
+    /**
+     *
+     * @param ProductSelectionAddProductAction|callable $action
+     * @return $this
+     */
+    public function addProduct($action = null)
+    {
+        $this->addAction($this->resolveAction(ProductSelectionAddProductAction::class, $action));
+        return $this;
+    }
+
+    /**
+     *
+     * @param ProductSelectionChangeNameAction|callable $action
+     * @return $this
+     */
+    public function changeName($action = null)
+    {
+        $this->addAction($this->resolveAction(ProductSelectionChangeNameAction::class, $action));
+        return $this;
+    }
+
+    /**
+     *
+     * @param ProductSelectionRemoveProductAction|callable $action
+     * @return $this
+     */
+    public function removeProduct($action = null)
+    {
+        $this->addAction($this->resolveAction(ProductSelectionRemoveProductAction::class, $action));
+        return $this;
+    }
+
+    /**
+     *
+     * @param ProductSelectionSetKeyAction|callable $action
+     * @return $this
+     */
+    public function setKey($action = null)
+    {
+        $this->addAction($this->resolveAction(ProductSelectionSetKeyAction::class, $action));
+        return $this;
+    }
+
+    /**
+     * @return ProductSelectionsActionBuilder
+     */
+    public static function of()
+    {
+        return new self();
+    }
+
+    /**
+     * @param $class
+     * @param $action
+     * @return AbstractAction
+     * @throws InvalidArgumentException
+     */
+    private function resolveAction($class, $action = null)
+    {
+        if (is_null($action) || is_callable($action)) {
+            $callback = $action;
+            $emptyAction = $class::of();
+            $action = $this->callback($emptyAction, $callback);
+        }
+        if ($action instanceof $class) {
+            return $action;
+        }
+        throw new InvalidArgumentException(
+            sprintf('Expected method to be called with or callable to return %s', $class)
+        );
+    }
+
+    /**
+     * @param $action
+     * @param callable $callback
+     * @return AbstractAction
+     */
+    private function callback($action, callable $callback = null)
+    {
+        if (!is_null($callback)) {
+            $action = $callback($action);
+        }
+        return $action;
+    }
+
+    /**
+     * @param AbstractAction $action
+     * @return $this;
+     */
+    public function addAction(AbstractAction $action)
+    {
+        $this->actions[] = $action;
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function getActions()
+    {
+        return $this->actions;
+    }
+
+
+    /**
+     * @param array $actions
+     * @return $this
+     */
+    public function setActions(array $actions)
+    {
+        $this->actions = $actions;
+        return $this;
+    }
+}

--- a/src/Core/Builder/Update/StoresActionBuilder.php
+++ b/src/Core/Builder/Update/StoresActionBuilder.php
@@ -5,6 +5,7 @@ namespace Commercetools\Core\Builder\Update;
 use Commercetools\Core\Error\InvalidArgumentException;
 use Commercetools\Core\Request\AbstractAction;
 use Commercetools\Core\Request\Stores\Command\StoreAddDistributionChannelAction;
+use Commercetools\Core\Request\Stores\Command\StoreAddProductSelectionAction;
 use Commercetools\Core\Request\Stores\Command\StoreAddSupplyChannelAction;
 use Commercetools\Core\Request\Stores\Command\StoreRemoveDistributionChannelAction;
 use Commercetools\Core\Request\Stores\Command\StoreRemoveSupplyChannelAction;
@@ -25,6 +26,17 @@ class StoresActionBuilder
     public function addDistributionChannel($action = null)
     {
         $this->addAction($this->resolveAction(StoreAddDistributionChannelAction::class, $action));
+        return $this;
+    }
+
+    /**
+     * @link https://docs.commercetools.com/api/projects/stores#add-distribution-channel
+     * @param StoreAddProductSelectionAction|callable $action
+     * @return $this
+     */
+    public function addProductSelection($action = null)
+    {
+        $this->addAction($this->resolveAction(StoreAddProductSelectionAction::class, $action));
         return $this;
     }
 

--- a/src/Core/Model/ProductSelection/AssignedProductReference.php
+++ b/src/Core/Model/ProductSelection/AssignedProductReference.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace Commercetools\Core\Model\ProductSelection;
+
+use Commercetools\Core\Model\Common\CreatedBy;
+use Commercetools\Core\Model\Common\DateTimeDecorator;
+use Commercetools\Core\Model\Common\LastModifiedBy;
+use Commercetools\Core\Model\Common\LocalizedString;
+use Commercetools\Core\Model\Common\ReferenceCollection;
+use Commercetools\Core\Model\Common\Resource;
+use Commercetools\Core\Model\Product\ProductReference;
+use DateTime;
+
+/**
+ * @package Commercetools\Core\Model\ProductSelection
+ * @link https://docs.commercetools.com/http-api-projects-productSelections.html#productselection
+ * @method string getId()
+ * @method ProductSelection setId(string $id = null)
+ * @method int getVersion()
+ * @method ProductSelection setVersion(int $version = null)
+ * @method DateTimeDecorator getCreatedAt()
+ * @method ProductSelection setCreatedAt(DateTime $createdAt = null)
+ * @method DateTimeDecorator getLastModifiedAt()
+ * @method ProductSelection setLastModifiedAt(DateTime $lastModifiedAt = null)
+ * @method LocalizedString getName()
+ * @method ProductSelection setName(LocalizedString $name = null)
+ * @method LocalizedString getDescription()
+ * @method ProductSelection setDescription(LocalizedString $description = null)
+ * @method mixed getPredicate()
+ * @method ProductSelection setPredicate($predicate = null)
+ * @method string getSortOrder()
+ * @method ProductSelection setSortOrder(string $sortOrder = null)
+ * @method bool getIsActive()
+ * @method ProductSelection setIsActive(bool $isActive = null)
+ * @method ReferenceCollection getReferences()
+ * @method ProductSelection setReferences(ReferenceCollection $references = null)
+ * @method DateTimeDecorator getValidFrom()
+ * @method ProductSelection setValidFrom(DateTime $validFrom = null)
+ * @method DateTimeDecorator getValidUntil()
+ * @method ProductSelection setValidUntil(DateTime $validUntil = null)
+ * @method CreatedBy getCreatedBy()
+ * @method ProductSelection setCreatedBy(CreatedBy $createdBy = null)
+ * @method LastModifiedBy getLastModifiedBy()
+ * @method ProductSelection setLastModifiedBy(LastModifiedBy $lastModifiedBy = null)
+ * @method string getKey()
+ * @method ProductSelection setKey(string $key = null)
+ * @method int getProductCount()
+ * @method ProductSelection setProductCount(int $productCount = null)
+ * @method ProductReference getProduct()
+ * @method AssignedProductReference setProduct(ProductReference $product = null)
+ * @method ProductSelectionReference getProductSelection()
+ * @method AssignedProductReference setProductSelection(ProductSelectionReference $productSelection = null)
+ */
+class AssignedProductReference extends Resource
+{
+    public function fieldDefinitions()
+    {
+        return [
+            'product' => [static::TYPE => ProductReference::class],
+        ];
+    }
+}

--- a/src/Core/Model/ProductSelection/ProductSelection.php
+++ b/src/Core/Model/ProductSelection/ProductSelection.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Commercetools\Core\Model\ProductSelection;
+
+use Commercetools\Core\Model\Common\CreatedBy;
+use Commercetools\Core\Model\Common\DateTimeDecorator;
+use Commercetools\Core\Model\Common\LastModifiedBy;
+use Commercetools\Core\Model\Common\LocalizedString;
+use Commercetools\Core\Model\Common\ReferenceCollection;
+use Commercetools\Core\Model\Common\Resource;
+use DateTime;
+
+/**
+ * @package Commercetools\Core\Model\ProductSelection
+ * @link https://docs.commercetools.com/http-api-projects-productSelections.html#productselection
+ * @method string getId()
+ * @method ProductSelection setId(string $id = null)
+ * @method int getVersion()
+ * @method ProductSelection setVersion(int $version = null)
+ * @method DateTimeDecorator getCreatedAt()
+ * @method ProductSelection setCreatedAt(DateTime $createdAt = null)
+ * @method DateTimeDecorator getLastModifiedAt()
+ * @method ProductSelection setLastModifiedAt(DateTime $lastModifiedAt = null)
+ * @method LocalizedString getName()
+ * @method ProductSelection setName(LocalizedString $name = null)
+ * @method CreatedBy getCreatedBy()
+ * @method ProductSelection setCreatedBy(CreatedBy $createdBy = null)
+ * @method LastModifiedBy getLastModifiedBy()
+ * @method ProductSelection setLastModifiedBy(LastModifiedBy $lastModifiedBy = null)
+ * @method string getKey()
+ * @method ProductSelection setKey(string $key = null)
+ * @method int getProductCount()
+ * @method ProductSelection setProductCount(int $productCount = null)
+ * @method ProductSelectionReference getReference()
+ */
+class ProductSelection extends Resource
+{
+    public function fieldDefinitions()
+    {
+        return [
+            'id' => [static::TYPE => 'string'],
+            'version' => [static::TYPE => 'int'],
+            'key' => [static::TYPE => 'string'],
+            'createdAt' => [
+                static::TYPE => DateTime::class,
+                static::DECORATOR => DateTimeDecorator::class
+            ],
+            'lastModifiedAt' => [
+                static::TYPE => DateTime::class,
+                static::DECORATOR => DateTimeDecorator::class
+            ],
+            'lastModifiedBy' => [static::TYPE => LastModifiedBy::class],
+            'createdBy' => [static::TYPE => CreatedBy::class],
+            'name' => [static::TYPE => LocalizedString::class],
+            'productCount' => [static::TYPE => 'int'],
+        ];
+    }
+}

--- a/src/Core/Model/ProductSelection/ProductSelectionAssignment.php
+++ b/src/Core/Model/ProductSelection/ProductSelectionAssignment.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Commercetools\Core\Model\ProductSelection;
+
+use Commercetools\Core\Model\Common\CreatedBy;
+use Commercetools\Core\Model\Common\DateTimeDecorator;
+use Commercetools\Core\Model\Common\LastModifiedBy;
+use Commercetools\Core\Model\Common\LocalizedString;
+use Commercetools\Core\Model\Common\ReferenceCollection;
+use Commercetools\Core\Model\Common\Resource;
+use Commercetools\Core\Model\Product\ProductReference;
+use DateTime;
+
+/**
+ * @package Commercetools\Core\Model\ProductSelection
+ * @method ProductReference getProduct()
+ * @method ProductSelectionAssignment setProduct(ProductReference $product = null)
+ * @method ProductSelectionReference getProductSelection()
+ * @method ProductSelectionAssignment setProductSelection(ProductSelectionReference $productSelection = null)
+ */
+class ProductSelectionAssignment extends Resource
+{
+    public function fieldDefinitions()
+    {
+        return [
+            'product' => [static::TYPE => ProductReference::class],
+            'productSelection' => [static::TYPE => ProductSelectionReference::class],
+        ];
+    }
+}

--- a/src/Core/Model/ProductSelection/ProductSelectionCollection.php
+++ b/src/Core/Model/ProductSelection/ProductSelectionCollection.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace Commercetools\Core\Model\ProductSelection;
+
+use Commercetools\Core\Model\Common\Collection;
+
+/**
+ * @package Commercetools\Core\Model\ProductSelection
+ * @link https://docs.commercetools.com/http-api-projects-productSelections.html#productselection
+ * @method ProductSelection current()
+ * @method ProductSelectionCollection add(ProductSelection $element)
+ * @method ProductSelection getAt($offset)
+ * @method ProductSelection getById($offset)
+ */
+class ProductSelectionCollection extends Collection
+{
+    protected $type = ProductSelection::class;
+}

--- a/src/Core/Model/ProductSelection/ProductSelectionDraft.php
+++ b/src/Core/Model/ProductSelection/ProductSelectionDraft.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Commercetools\Core\Model\ProductSelection;
+
+use Commercetools\Core\Model\Common\Context;
+use Commercetools\Core\Model\Common\JsonObject;
+use Commercetools\Core\Model\Common\LocalizedString;
+
+/**
+ * @package Commercetools\Core\Model\ProductSelection
+ * @link https://docs.commercetools.com/http-api-projects-productSelection.html#productselectiondraft
+ * @method LocalizedString getName()
+ * @method ProductSelectionDraft setName(LocalizedString $name = null)
+ * @method string getKey()
+ * @method ProductSelectionDraft setKey(string $key = null)
+ */
+class ProductSelectionDraft extends JsonObject
+{
+    public function fieldDefinitions()
+    {
+        return [
+            'key' => [static::TYPE => 'string'],
+            'name' => [static::TYPE => LocalizedString::class],
+        ];
+    }
+
+    /**
+     * @param LocalizedString $name
+     * @param Context|callable $context
+     * @return ProductSelectionDraft
+     */
+    public static function ofName(
+        LocalizedString $name,
+        $context = null
+    ) {
+        return static::of($context)->setName($name);
+    }
+}

--- a/src/Core/Model/ProductSelection/ProductSelectionReference.php
+++ b/src/Core/Model/ProductSelection/ProductSelectionReference.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Commercetools\Core\Model\ProductSelection;
+
+use Commercetools\Core\Model\Common\Context;
+use Commercetools\Core\Model\Common\Reference;
+
+/**
+ * @package Commercetools\Core\Model\ProductSelection
+ * @ramlTestIgnoreFields('key')
+ * @link https://docs.commercetools.com/http-api-types.html#reference-types
+ * @link https://docs.commercetools.com/http-api-projects-productSelections.html#productselection
+ * @method string getTypeId()
+ * @method ProductSelectionReference setTypeId(string $typeId = null)
+ * @method string getId()
+ * @method ProductSelectionReference setId(string $id = null)
+ * @method ProductSelection getObj()
+ * @method ProductSelectionReference setObj(ProductSelection $obj = null)
+ * @method string getKey()
+ * @method ProductSelectionReference setKey(string $key = null)
+ */
+class ProductSelectionReference extends Reference
+{
+    const TYPE_PRODUCT_SELECTION = 'product-selection';
+    const TYPE_CLASS = ProductSelection::class;
+
+    /**
+     * @param $id
+     * @param Context|callable $context
+     * @return ProductSelectionReference
+     */
+    public static function ofId($id, $context = null)
+    {
+        return static::ofTypeAndId(static::TYPE_PRODUCT_SELECTION, $id, $context);
+    }
+}

--- a/src/Core/Model/Store/ProductSelectionSetting.php
+++ b/src/Core/Model/Store/ProductSelectionSetting.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Commercetools\Core\Model\Store;
+
+use Commercetools\Core\Model\Channel\ChannelReference;
+use Commercetools\Core\Model\Common\DateTimeDecorator;
+use Commercetools\Core\Model\Common\LocalizedString;
+use Commercetools\Core\Model\Common\Resource;
+use Commercetools\Core\Model\CustomField\CustomFieldObject;
+use Commercetools\Core\Model\ProductSelection\ProductSelectionReference;
+use DateTime;
+
+/**
+ * @package Commercetools\Core\Model\Store
+ * @link https://docs.commercetools.com/http-api-projects-stores#store
+ * @method ProductSelectionReference getProductSelection()
+ * @method ProductSelectionSetting setProductSelection(ProductSelectionReference $productSelection = null)
+ * @method bool getActive()
+ * @method ProductSelectionSetting setActive(bool $active = null)
+ */
+class ProductSelectionSetting extends Resource
+{
+    public function fieldDefinitions()
+    {
+        return [
+            'productSelection' => [static::TYPE => ProductSelectionReference::class],
+            'active' => [static::TYPE => 'bool'],
+        ];
+    }
+}

--- a/src/Core/Model/Store/ProductSelectionSettingDraft.php
+++ b/src/Core/Model/Store/ProductSelectionSettingDraft.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Commercetools\Core\Model\Store;
+
+use Commercetools\Core\Model\Channel\ChannelReference;
+use Commercetools\Core\Model\Common\Context;
+use Commercetools\Core\Model\Common\JsonObject;
+use Commercetools\Core\Model\Common\LocalizedString;
+use Commercetools\Core\Model\CustomField\CustomFieldObject;
+use Commercetools\Core\Model\CustomField\CustomFieldObjectDraft;
+use Commercetools\Core\Model\ProductSelection\ProductSelectionReference;
+
+/**
+ * @package Commercetools\Core\Model\Store
+ * @link https://docs.commercetools.com/http-api-projects-stores#storedraft
+ *
+ * @method ProductSelectionReference getProductSelection()
+ * @method ProductSelectionSettingDraft setProductSelection(ProductSelectionReference $productSelection = null)
+ * @method bool getActive()
+ * @method ProductSelectionSettingDraft setActive(bool $active = null)
+ */
+class ProductSelectionSettingDraft extends JsonObject
+{
+    public function fieldDefinitions()
+    {
+        return [
+            'productSelection' => [static::TYPE => ProductSelectionReference::class],
+            'active' => [static::TYPE => 'bool'],
+        ];
+    }
+}

--- a/src/Core/Model/Store/Store.php
+++ b/src/Core/Model/Store/Store.php
@@ -38,6 +38,8 @@ use DateTime;
  * @method Store setSupplyChannels(array $supplyChannels = null)
  * @method CustomFieldObject getCustom()
  * @method Store setCustom(CustomFieldObject $custom = null)
+ * @method array getProductSelections()
+ * @method Store setProductSelections(array $productSelections = null)
  * @method StoreReference getReference()
  */
 class Store extends Resource
@@ -60,6 +62,7 @@ class Store extends Resource
             'languages' => [static::TYPE => 'array'],
             'distributionChannels' => [static::TYPE => 'array'],
             'supplyChannels' => [static::TYPE => 'array'],
+            'productSelections' => [static::TYPE => 'array'],
             'custom' => [static::TYPE => CustomFieldObject::class],
         ];
     }

--- a/src/Core/Request/InStores/InStoreRequests.php
+++ b/src/Core/Request/InStores/InStoreRequests.php
@@ -52,6 +52,14 @@ use Commercetools\Core\Request\Orders\OrderDeleteRequest;
 use Commercetools\Core\Request\Orders\OrderQueryRequest;
 use Commercetools\Core\Request\Orders\OrderUpdateByOrderNumberRequest;
 use Commercetools\Core\Request\Orders\OrderUpdateRequest;
+use Commercetools\Core\Request\ProductSelections\ProductSelectionByIdGetRequest;
+use Commercetools\Core\Request\ProductSelections\ProductSelectionByKeyGetRequest;
+use Commercetools\Core\Request\ProductSelections\ProductSelectionCreateRequest;
+use Commercetools\Core\Request\ProductSelections\ProductSelectionDeleteByKeyRequest;
+use Commercetools\Core\Request\ProductSelections\ProductSelectionDeleteRequest;
+use Commercetools\Core\Request\ProductSelections\ProductSelectionQueryRequest;
+use Commercetools\Core\Request\ProductSelections\ProductSelectionUpdateByKeyRequest;
+use Commercetools\Core\Request\ProductSelections\ProductSelectionUpdateRequest;
 use Commercetools\Core\Request\ShippingMethods\ShippingMethodByCartIdGetRequest;
 use Commercetools\Core\Request\ShoppingLists\ShoppingListByIdGetRequest;
 use Commercetools\Core\Request\ShoppingLists\ShoppingListByKeyGetRequest;
@@ -121,6 +129,14 @@ class InStoreRequests
         MeShoppingListUpdateByKeyRequest::class => 1,
         MeShoppingListDeleteRequest::class => 1,
         MeShoppingListDeleteByKeyRequest::class => 1,
+        ProductSelectionByIdGetRequest::class => 1,
+        ProductSelectionByKeyGetRequest::class => 1,
+        ProductSelectionCreateRequest::class => 1,
+        ProductSelectionDeleteByKeyRequest::class => 1,
+        ProductSelectionDeleteRequest::class => 1,
+        ProductSelectionQueryRequest::class => 1,
+        ProductSelectionUpdateByKeyRequest::class => 1,
+        ProductSelectionUpdateRequest::class => 1,
     ];
 
     public function can($request)

--- a/src/Core/Request/ProductSelections/Command/ProductSelectionAddProductAction.php
+++ b/src/Core/Request/ProductSelections/Command/ProductSelectionAddProductAction.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Commercetools\Core\Request\ProductSelections\Command;
+
+use Commercetools\Core\Model\Common\Context;
+use Commercetools\Core\Model\Product\ProductReference;
+use Commercetools\Core\Model\ProductSelection\ProductSelectionReference;
+use Commercetools\Core\Request\AbstractAction;
+
+/**
+ * @package Commercetools\Core\Request\ProductSelections\Command
+ * @method string getAction()
+ * @method ProductSelectionAddProductAction setAction(string $action = null)
+ * @method ProductReference getProduct()
+ * @method ProductSelectionAddProductAction setProduct(ProductReference $product = null)
+ */
+class ProductSelectionAddProductAction extends AbstractAction
+{
+    public function fieldDefinitions()
+    {
+        return [
+            'action' => [static::TYPE => 'string'],
+            'product' => [static::TYPE => ProductReference::class],
+        ];
+    }
+
+    /**
+     * @param array $data
+     * @param Context|callable $context
+     */
+    public function __construct(array $data = [], $context = null)
+    {
+        parent::__construct($data, $context);
+        $this->setAction('addProduct');
+    }
+
+    /**
+     * @param ProductReference $product
+     * @param Context|callable $context
+     * @return ProductSelectionAddProductAction
+     */
+    public static function ofProduct($product, $context = null)
+    {
+        return static::of($context)->setProduct($product);
+    }
+}

--- a/src/Core/Request/ProductSelections/Command/ProductSelectionChangeNameAction.php
+++ b/src/Core/Request/ProductSelections/Command/ProductSelectionChangeNameAction.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Commercetools\Core\Request\ProductSelections\Command;
+
+use Commercetools\Core\Model\Common\Context;
+use Commercetools\Core\Model\Common\LocalizedString;
+use Commercetools\Core\Request\AbstractAction;
+
+/**
+ * @package Commercetools\Core\Request\ProductSelections\Command
+ * @method string getAction()
+ * @method ProductSelectionChangeNameAction setAction(string $action = null)
+ * @method LocalizedString getName()
+ * @method ProductSelectionChangeNameAction setName(LocalizedString $name = null)
+ */
+class ProductSelectionChangeNameAction extends AbstractAction
+{
+    public function fieldDefinitions()
+    {
+        return [
+            'action' => [static::TYPE => 'string'],
+            'name' => [static::TYPE => LocalizedString::class],
+        ];
+    }
+
+    /**
+     * @param array $data
+     * @param Context|callable $context
+     */
+    public function __construct(array $data = [], $context = null)
+    {
+        parent::__construct($data, $context);
+        $this->setAction('changeName');
+    }
+
+    /**
+     * @param LocalizedString $name
+     * @param Context|callable $context
+     * @return ProductSelectionChangeNameAction
+     */
+    public static function ofName(LocalizedString $name, $context = null)
+    {
+        return static::of($context)->setName($name);
+    }
+}

--- a/src/Core/Request/ProductSelections/Command/ProductSelectionRemoveProductAction.php
+++ b/src/Core/Request/ProductSelections/Command/ProductSelectionRemoveProductAction.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Commercetools\Core\Request\ProductSelections\Command;
+
+use Commercetools\Core\Model\Common\Context;
+use Commercetools\Core\Model\Product\ProductReference;
+use Commercetools\Core\Model\ProductSelection\ProductSelectionReference;
+use Commercetools\Core\Request\AbstractAction;
+
+/**
+ * @package Commercetools\Core\Request\ProductSelections\Command
+ * @method string getAction()
+ * @method ProductSelectionRemoveProductAction setAction(string $action = null)
+ * @method ProductReference getProduct()
+ * @method ProductSelectionRemoveProductAction setProduct(ProductReference $product = null)
+ */
+class ProductSelectionRemoveProductAction extends AbstractAction
+{
+    public function fieldDefinitions()
+    {
+        return [
+            'action' => [static::TYPE => 'string'],
+            'product' => [static::TYPE => ProductReference::class],
+        ];
+    }
+
+    /**
+     * @param array $data
+     * @param Context|callable $context
+     */
+    public function __construct(array $data = [], $context = null)
+    {
+        parent::__construct($data, $context);
+        $this->setAction('removeProduct');
+    }
+
+    /**
+     * @param ProductReference $product
+     * @param Context|callable $context
+     * @return ProductSelectionRemoveProductAction
+     */
+    public static function ofProduct($product, $context = null)
+    {
+        return static::of($context)->setProduct($product);
+    }
+}

--- a/src/Core/Request/ProductSelections/Command/ProductSelectionSetKeyAction.php
+++ b/src/Core/Request/ProductSelections/Command/ProductSelectionSetKeyAction.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace Commercetools\Core\Request\ProductSelections\Command;
+
+use Commercetools\Core\Model\Common\Context;
+use Commercetools\Core\Request\AbstractAction;
+
+/**
+ * @package Commercetools\Core\Request\ProductSelections\Command
+ * @method string getAction()
+ * @method ProductSelectionSetKeyAction setAction(string $action = null)
+ * @method string getKey()
+ * @method ProductSelectionSetKeyAction setKey(string $key = null)
+ */
+class ProductSelectionSetKeyAction extends AbstractAction
+{
+    public function fieldDefinitions()
+    {
+        return [
+            'action' => [static::TYPE => 'string'],
+            'key' => [static::TYPE => 'string']
+        ];
+    }
+
+    /**
+     * @param array $data
+     * @param Context|callable $context
+     */
+    public function __construct(array $data = [], $context = null)
+    {
+        parent::__construct($data, $context);
+        $this->setAction('setKey');
+    }
+
+    /**
+     * @param string $key
+     * @param Context|callable $context
+     * @return ProductSelectionSetKeyAction
+     */
+    public static function ofKey($key, $context = null)
+    {
+        return static::of($context)->setKey($key);
+    }
+}

--- a/src/Core/Request/ProductSelections/ProductSelectionByIdGetRequest.php
+++ b/src/Core/Request/ProductSelections/ProductSelectionByIdGetRequest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Commercetools\Core\Request\ProductSelections;
+
+use Commercetools\Core\Model\Common\Context;
+use Commercetools\Core\Request\AbstractByIdGetRequest;
+use Commercetools\Core\Model\ProductSelection\ProductSelection;
+use Commercetools\Core\Response\ApiResponseInterface;
+use Commercetools\Core\Model\MapperInterface;
+
+/**
+ * @package Commercetools\Core\Request\ProductSelections
+ * @link https://docs.commercetools.com/http-api-projects-productSelections.html#get-a-productselection-by-id
+ * @method ProductSelection mapResponse(ApiResponseInterface $response)
+ * @method ProductSelection mapFromResponse(ApiResponseInterface $response, MapperInterface $mapper = null)
+ */
+class ProductSelectionByIdGetRequest extends AbstractByIdGetRequest
+{
+    protected $resultClass = ProductSelection::class;
+
+    /**
+     * @param string $id
+     * @param Context $context
+     */
+    public function __construct($id, Context $context = null)
+    {
+        parent::__construct(ProductSelectionsEndpoint::endpoint(), $id, $context);
+    }
+
+    /**
+     * @param string $id
+     * @param Context $context
+     * @return static
+     */
+    public static function ofId($id, Context $context = null)
+    {
+        return new static($id, $context);
+    }
+}

--- a/src/Core/Request/ProductSelections/ProductSelectionByIdProductsGetRequest.php
+++ b/src/Core/Request/ProductSelections/ProductSelectionByIdProductsGetRequest.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Commercetools\Core\Request\ProductSelections;
+
+use Commercetools\Core\Model\Common\Context;
+use Commercetools\Core\Model\MapperInterface;
+use Commercetools\Core\Model\ProductSelection\ProductSelection;
+use Commercetools\Core\Request\AbstractByIdGetRequest;
+use Commercetools\Core\Response\ApiResponseInterface;
+
+/**
+ * @package Commercetools\Core\Request\ProductSelections
+ * @method ProductSelection mapResponse(ApiResponseInterface $response)
+ * @method ProductSelection mapFromResponse(ApiResponseInterface $response, MapperInterface $mapper = null)
+ */
+class ProductSelectionByIdProductsGetRequest extends AbstractByIdGetRequest
+{
+    protected $resultClass = ProductSelection::class;
+
+    /**
+     * @param string $id
+     * @param Context $context
+     */
+    public function __construct($id, Context $context = null)
+    {
+        parent::__construct(ProductSelectionsEndpoint::endpoint(), $id, $context);
+    }
+
+    /**
+     * @param string $id
+     * @param Context $context
+     * @return static
+     */
+    public static function ofId($id, Context $context = null)
+    {
+        return new static($id, $context);
+    }
+
+    /**
+     * @return string
+     * @internal
+     */
+    protected function getPath()
+    {
+        return (string)$this->getEndpoint() . '/'. $this->id . '/products' . $this->getParamString();
+    }
+}

--- a/src/Core/Request/ProductSelections/ProductSelectionByKeyGetRequest.php
+++ b/src/Core/Request/ProductSelections/ProductSelectionByKeyGetRequest.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace Commercetools\Core\Request\ProductSelections;
+
+use Commercetools\Core\Model\Common\Context;
+use Commercetools\Core\Model\ProductSelection\ProductSelection;
+use Commercetools\Core\Request\AbstractByKeyGetRequest;
+use Commercetools\Core\Response\ApiResponseInterface;
+use Commercetools\Core\Model\MapperInterface;
+
+/**
+ * @package Commercetools\Core\Request\ProductSelections
+ * @link https://docs.commercetools.com/http-api-projects-productSelections.html#get-a-productselection-by-key
+ * @method ProductSelection mapResponse(ApiResponseInterface $response)
+ * @method ProductSelection mapFromResponse(ApiResponseInterface $response, MapperInterface $mapper = null)
+ */
+class ProductSelectionByKeyGetRequest extends AbstractByKeyGetRequest
+{
+    protected $resultClass = ProductSelection::class;
+
+    /**
+     * @param string $key
+     * @param Context $context
+     */
+    public function __construct($key, Context $context = null)
+    {
+        parent::__construct(ProductSelectionsEndpoint::endpoint(), $key, $context);
+    }
+
+    /**
+     * @param string $key
+     * @param Context $context
+     * @return static
+     */
+    public static function ofKey($key, Context $context = null)
+    {
+        return new static($key, $context);
+    }
+}

--- a/src/Core/Request/ProductSelections/ProductSelectionByKeyProductsGetRequest.php
+++ b/src/Core/Request/ProductSelections/ProductSelectionByKeyProductsGetRequest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Commercetools\Core\Request\ProductSelections;
+
+use Commercetools\Core\Client\JsonRequest;
+use Commercetools\Core\Model\Common\Context;
+use Commercetools\Core\Model\ProductSelection\ProductSelection;
+use Commercetools\Core\Request\AbstractByKeyGetRequest;
+use Commercetools\Core\Response\ApiResponseInterface;
+use Commercetools\Core\Model\MapperInterface;
+
+/**
+ * @package Commercetools\Core\Request\ProductSelections
+ * @method ProductSelection mapResponse(ApiResponseInterface $response)
+ * @method ProductSelection mapFromResponse(ApiResponseInterface $response, MapperInterface $mapper = null)
+ */
+class ProductSelectionByKeyProductsGetRequest extends AbstractByKeyGetRequest
+{
+    protected $resultClass = ProductSelection::class;
+
+    /**
+     * @param string $key
+     * @param Context $context
+     */
+    public function __construct($key, Context $context = null)
+    {
+        parent::__construct(ProductSelectionsEndpoint::endpoint(), $key, $context);
+    }
+
+    /**
+     * @param string $key
+     * @param Context $context
+     * @return static
+     */
+    public static function ofKey($key, Context $context = null)
+    {
+        return new static($key, $context);
+    }
+
+
+    /**
+     * @return string
+     * @internal
+     */
+    protected function getPath()
+    {
+        return (string)$this->getEndpoint() . '/key=' . $this->getKey() . '/products' . $this->getParamString();
+    }
+}

--- a/src/Core/Request/ProductSelections/ProductSelectionCreateRequest.php
+++ b/src/Core/Request/ProductSelections/ProductSelectionCreateRequest.php
@@ -1,0 +1,40 @@
+<?php
+
+namespace Commercetools\Core\Request\ProductSelections;
+
+use Commercetools\Core\Model\Common\Context;
+use Commercetools\Core\Model\ProductSelection\ProductSelectionDraft;
+use Commercetools\Core\Request\AbstractCreateRequest;
+use Commercetools\Core\Model\ProductSelection\ProductSelection;
+use Commercetools\Core\Response\ApiResponseInterface;
+use Commercetools\Core\Model\MapperInterface;
+
+/**
+ * @package Commercetools\Core\Request\ProductSelections
+ * @link https://docs.commercetools.com/http-api-projects-productSelections.html#create-a-productselection
+ * @method ProductSelection mapResponse(ApiResponseInterface $response)
+ * @method ProductSelection mapFromResponse(ApiResponseInterface $response, MapperInterface $mapper = null)
+ */
+class ProductSelectionCreateRequest extends AbstractCreateRequest
+{
+    protected $resultClass = ProductSelection::class;
+
+    /**
+     * @param ProductSelectionDraft $productSelection
+     * @param Context $context
+     */
+    public function __construct(ProductSelectionDraft $productSelection, Context $context = null)
+    {
+        parent::__construct(ProductSelectionsEndpoint::endpoint(), $productSelection, $context);
+    }
+
+    /**
+     * @param ProductSelectionDraft $productSelection
+     * @param Context $context
+     * @return static
+     */
+    public static function ofDraft(ProductSelectionDraft $productSelection, Context $context = null)
+    {
+        return new static($productSelection, $context);
+    }
+}

--- a/src/Core/Request/ProductSelections/ProductSelectionDeleteByKeyRequest.php
+++ b/src/Core/Request/ProductSelections/ProductSelectionDeleteByKeyRequest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Commercetools\Core\Request\ProductSelections;
+
+use Commercetools\Core\Model\Common\Context;
+use Commercetools\Core\Request\AbstractDeleteByKeyRequest;
+use Commercetools\Core\Model\ProductSelection\ProductSelection;
+use Commercetools\Core\Response\ApiResponseInterface;
+use Commercetools\Core\Model\MapperInterface;
+
+/**
+ * @package Commercetools\Core\Request\ProductSelections
+ * @link https://docs.commercetools.com/http-api-projects-productSelections.html#delete-productselection-by-key
+ * @method ProductSelection mapResponse(ApiResponseInterface $response)
+ * @method ProductSelection mapFromResponse(ApiResponseInterface $response, MapperInterface $mapper = null)
+ */
+class ProductSelectionDeleteByKeyRequest extends AbstractDeleteByKeyRequest
+{
+    protected $resultClass = ProductSelection::class;
+
+    /**
+     * @param string $key
+     * @param int $version
+     * @param Context $context
+     */
+    public function __construct($key, $version, Context $context = null)
+    {
+        parent::__construct(ProductSelectionsEndpoint::endpoint(), $key, $version, $context);
+    }
+
+    /**
+     * @param string $key
+     * @param int $version
+     * @param Context $context
+     * @return static
+     */
+    public static function ofKeyAndVersion($key, $version, Context $context = null)
+    {
+        return new static($key, $version, $context);
+    }
+}

--- a/src/Core/Request/ProductSelections/ProductSelectionDeleteRequest.php
+++ b/src/Core/Request/ProductSelections/ProductSelectionDeleteRequest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace Commercetools\Core\Request\ProductSelections;
+
+use Commercetools\Core\Model\Common\Context;
+use Commercetools\Core\Request\AbstractDeleteRequest;
+use Commercetools\Core\Model\ProductSelection\ProductSelection;
+use Commercetools\Core\Response\ApiResponseInterface;
+use Commercetools\Core\Model\MapperInterface;
+
+/**
+ * @package Commercetools\Core\Request\ProductSelections
+ * @link https://docs.commercetools.com/http-api-projects-product=selection.html#delete-productselection-by-id
+ * @method ProductSelection mapResponse(ApiResponseInterface $response)
+ * @method ProductSelection mapFromResponse(ApiResponseInterface $response, MapperInterface $mapper = null)
+ */
+class ProductSelectionDeleteRequest extends AbstractDeleteRequest
+{
+    protected $resultClass = ProductSelection::class;
+
+    /**
+     * @param string $id
+     * @param int $version
+     * @param Context $context
+     */
+    public function __construct($id, $version, Context $context = null)
+    {
+        parent::__construct(ProductSelectionsEndpoint::endpoint(), $id, $version, $context);
+    }
+
+    /**
+     * @param string $id
+     * @param int $version
+     * @param Context $context
+     * @return static
+     */
+    public static function ofIdAndVersion($id, $version, Context $context = null)
+    {
+        return new static($id, $version, $context);
+    }
+}

--- a/src/Core/Request/ProductSelections/ProductSelectionQueryRequest.php
+++ b/src/Core/Request/ProductSelections/ProductSelectionQueryRequest.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ * @author @jenschude <jens.schulze@commercetools.de>
+ */
+
+namespace Commercetools\Core\Request\ProductSelections;
+
+use Commercetools\Core\Model\Common\Context;
+use Commercetools\Core\Request\AbstractQueryRequest;
+use Commercetools\Core\Model\ProductSelection\ProductSelectionCollection;
+use Commercetools\Core\Response\ApiResponseInterface;
+use Commercetools\Core\Model\MapperInterface;
+
+/**
+ * @package Commercetools\Core\Request\ProductSelections
+ * @link https://docs.commercetools.com/http-api-projects-productSelections.html#query-producttypes
+ * @method ProductSelectionCollection mapResponse(ApiResponseInterface $response)
+ * @method ProductSelectionCollection mapFromResponse(ApiResponseInterface $response, MapperInterface $mapper = null)
+ */
+class ProductSelectionQueryRequest extends AbstractQueryRequest
+{
+    protected $resultClass = ProductSelectionCollection::class;
+
+    /**
+     * @param Context $context
+     */
+    public function __construct(Context $context = null)
+    {
+        parent::__construct(ProductSelectionsEndpoint::endpoint(), $context);
+    }
+
+    /**
+     * @param Context $context
+     * @return static
+     */
+    public static function of(Context $context = null)
+    {
+        return new static($context);
+    }
+}

--- a/src/Core/Request/ProductSelections/ProductSelectionUpdateByKeyRequest.php
+++ b/src/Core/Request/ProductSelections/ProductSelectionUpdateByKeyRequest.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Commercetools\Core\Request\ProductSelections;
+
+use Commercetools\Core\Model\Common\Context;
+use Commercetools\Core\Model\MapperInterface;
+use Commercetools\Core\Model\ProductSelection\ProductSelection;
+use Commercetools\Core\Request\AbstractUpdateByKeyRequest;
+use Commercetools\Core\Response\ApiResponseInterface;
+
+/**
+ * @package Commercetools\Core\Request\ProductSelections
+ *
+ * @method ProductSelection mapResponse(ApiResponseInterface $response)
+ * @method ProductSelection mapFromResponse(ApiResponseInterface $response, MapperInterface $mapper = null)
+ */
+class ProductSelectionUpdateByKeyRequest extends AbstractUpdateByKeyRequest
+{
+    protected $resultClass = ProductSelection::class;
+
+    /**
+     * @param string $key
+     * @param int $version
+     * @param array $actions
+     * @param Context $context
+     */
+    public function __construct($key, $version, array $actions = [], Context $context = null)
+    {
+        parent::__construct(ProductSelectionsEndpoint::endpoint(), $key, $version, $actions, $context);
+    }
+
+    /**
+     * @param string $key
+     * @param int $version
+     * @param Context $context
+     * @return static
+     */
+    public static function ofKeyAndVersion($key, $version, Context $context = null)
+    {
+        return new static($key, $version, [], $context);
+    }
+}

--- a/src/Core/Request/ProductSelections/ProductSelectionUpdateRequest.php
+++ b/src/Core/Request/ProductSelections/ProductSelectionUpdateRequest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Commercetools\Core\Request\ProductSelections;
+
+use Commercetools\Core\Model\Common\Context;
+use Commercetools\Core\Model\MapperInterface;
+use Commercetools\Core\Model\ProductSelection\ProductSelection;
+use Commercetools\Core\Request\AbstractUpdateRequest;
+use Commercetools\Core\Request\PriceSelectTrait;
+use Commercetools\Core\Response\ApiResponseInterface;
+
+/**
+ * @package Commercetools\Core\Request\ProductSelections
+ * @link https://docs.commercetools.com/http-api-projects-product-selections.html#update-productselection
+ * @method ProductSelection mapResponse(ApiResponseInterface $response)
+ * @method ProductSelection mapFromResponse(ApiResponseInterface $response, MapperInterface $mapper = null)
+ */
+class ProductSelectionUpdateRequest extends AbstractUpdateRequest
+{
+    use PriceSelectTrait;
+
+    protected $resultClass = ProductSelection::class;
+
+    /**
+     * @param string $id
+     * @param int $version
+     * @param array $actions
+     * @param Context $context
+     */
+    public function __construct($id, $version, array $actions = [], Context $context = null)
+    {
+        parent::__construct(ProductSelectionsEndpoint::endpoint(), $id, $version, $actions, $context);
+    }
+
+    /**
+     * @param string $id
+     * @param int $version
+     * @param Context $context
+     * @return static
+     */
+    public static function ofIdAndVersion($id, $version, Context $context = null)
+    {
+        return new static($id, $version, [], $context);
+    }
+}

--- a/src/Core/Request/ProductSelections/ProductSelectionsEndpoint.php
+++ b/src/Core/Request/ProductSelections/ProductSelectionsEndpoint.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Commercetools\Core\Request\ProductSelections;
+
+use Commercetools\Core\Client\JsonEndpoint;
+
+class ProductSelectionsEndpoint
+{
+    /**
+     * @return JsonEndpoint
+     */
+    public static function endpoint()
+    {
+        return new JsonEndpoint('product-selections');
+    }
+}

--- a/src/Core/Request/Stores/Command/StoreAddProductSelectionAction.php
+++ b/src/Core/Request/Stores/Command/StoreAddProductSelectionAction.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Commercetools\Core\Request\Stores\Command;
+
+use Commercetools\Core\Model\Channel\ChannelReference;
+use Commercetools\Core\Model\Common\Context;
+use Commercetools\Core\Model\Store\ProductSelectionSettingDraft;
+use Commercetools\Core\Request\AbstractAction;
+
+/**
+ * @package Commercetools\Core\Request\Stores\Command
+ * @link https://docs.commercetools.com/api/projects/stores#add-distribution-channel
+ * @method string getAction()
+ * @method StoreAddProductSelectionAction setAction(string $action = null)
+ * @method ChannelReference getDistributionChannel()
+ * @method StoreAddProductSelectionAction setDistributionChannel(ChannelReference $productSelectionSettingDraft = null)
+ * @method ProductSelectionSettingDraft getProductSelection()
+ * @method StoreAddProductSelectionAction setProductSelection(ProductSelectionSettingDraft $productSelection = null)
+ */
+class StoreAddProductSelectionAction extends AbstractAction
+{
+    public function fieldDefinitions()
+    {
+        return [
+            'action' => [static::TYPE => 'string'],
+            'productSelection' => [static::TYPE => ProductSelectionSettingDraft::class],
+        ];
+    }
+
+    /**
+     * @param array $data
+     * @param Context|callable $context
+     */
+    public function __construct(array $data = [], $context = null)
+    {
+        parent::__construct($data, $context);
+        $this->setAction('addProductSelection');
+    }
+
+    /**
+     * @param ProductSelectionSettingDraft $productSelectionSettingDraft
+     * @param Context|callable $context
+     * @return StoreAddProductSelectionAction
+     */
+    public static function ofProductSelection(ProductSelectionSettingDraft $productSelectionSettingDraft, $context = null)
+    {
+        return static::of($context)->setProductSelection($productSelectionSettingDraft);
+    }
+}

--- a/tests/integration/ProductSelection/ProductSelectionFixture.php
+++ b/tests/integration/ProductSelection/ProductSelectionFixture.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace Commercetools\Core\IntegrationTests\ProductSelection;
+
+use Commercetools\Core\Client\ApiClient;
+use Commercetools\Core\Helper\Uuid;
+use Commercetools\Core\IntegrationTests\ResourceFixture;
+use Commercetools\Core\Model\Common\LocalizedString;
+use Commercetools\Core\Model\ProductSelection\ProductSelection;
+use Commercetools\Core\Model\ProductSelection\ProductSelectionDraft;
+use Commercetools\Core\Request\ProductSelections\ProductSelectionCreateRequest;
+use Commercetools\Core\Request\ProductSelections\ProductSelectionDeleteRequest;
+
+class ProductSelectionFixture extends ResourceFixture
+{
+    const CREATE_REQUEST_TYPE = ProductSelectionCreateRequest::class;
+    const DELETE_REQUEST_TYPE = ProductSelectionDeleteRequest::class;
+    const RAND_MAX = 10000;
+
+    final public static function uniqueProductSelectionString()
+    {
+        return 'test-' . Uuid::uuidv4();
+    }
+
+    final public static function defaultProductSelectionDraftFunction()
+    {
+        $uniqueProductSelectionString = self::uniqueProductSelectionString();
+        $draft = ProductSelectionDraft::of()->setKey($uniqueProductSelectionString)->setName(
+            LocalizedString::ofLangAndText('en', 'test-' . $uniqueProductSelectionString . '-name')
+        );
+
+        return $draft;
+    }
+
+    final public static function defaultProductSelectionDraftBuilderFunction(ProductSelectionDraft $draft)
+    {
+        return $draft;
+    }
+
+    final public static function defaultProductSelectionCreateFunction(ApiClient $client, ProductSelectionDraft $draft)
+    {
+        return parent::defaultCreateFunction($client, self::CREATE_REQUEST_TYPE, $draft);
+    }
+
+    final public static function defaultProductSelectionDeleteFunction(ApiClient $client, ProductSelection $resource)
+    {
+        return parent::defaultDeleteFunction($client, self::DELETE_REQUEST_TYPE, $resource);
+    }
+
+    final public static function withUpdateableDraftProductSelection(
+        ApiClient $client,
+        callable $draftBuilderFunction,
+        callable $assertFunction,
+        callable $createFunction = null,
+        callable $deleteFunction = null,
+        callable $draftFunction = null
+    ) {
+        if ($draftFunction == null) {
+            $draftFunction = [__CLASS__, 'defaultProductSelectionDraftFunction'];
+        }
+        if ($createFunction == null) {
+            $createFunction = [__CLASS__, 'defaultProductSelectionCreateFunction'];
+        }
+        if ($deleteFunction == null) {
+            $deleteFunction = [__CLASS__, 'defaultProductSelectionDeleteFunction'];
+        }
+
+        parent::withUpdateableDraftResource(
+            $client,
+            $draftBuilderFunction,
+            $assertFunction,
+            $createFunction,
+            $deleteFunction,
+            $draftFunction
+        );
+    }
+
+    final public static function withDraftProductSelection(
+        ApiClient $client,
+        callable $draftBuilderFunction,
+        callable $assertFunction,
+        callable $createFunction = null,
+        callable $deleteFunction = null,
+        callable $draftFunction = null
+    ) {
+        if ($draftFunction == null) {
+            $draftFunction = [__CLASS__, 'defaultProductSelectionDraftFunction'];
+        }
+        if ($createFunction == null) {
+            $createFunction = [__CLASS__, 'defaultProductSelectionCreateFunction'];
+        }
+        if ($deleteFunction == null) {
+            $deleteFunction = [__CLASS__, 'defaultProductSelectionDeleteFunction'];
+        }
+
+        parent::withDraftResource(
+            $client,
+            $draftBuilderFunction,
+            $assertFunction,
+            $createFunction,
+            $deleteFunction,
+            $draftFunction
+        );
+    }
+
+    final public static function withProductSelection(
+        ApiClient $client,
+        callable $assertFunction,
+        callable $createFunction = null,
+        callable $deleteFunction = null,
+        callable $draftFunction = null
+    ) {
+        self::withDraftProductSelection(
+            $client,
+            [__CLASS__, 'defaultProductSelectionDraftBuilderFunction'],
+            $assertFunction,
+            $createFunction,
+            $deleteFunction,
+            $draftFunction
+        );
+    }
+
+    final public static function withUpdateableProductSelection(
+        ApiClient $client,
+        callable $assertFunction,
+        callable $createFunction = null,
+        callable $deleteFunction = null,
+        callable $draftFunction = null
+    ) {
+        self::withUpdateableDraftProductSelection(
+            $client,
+            [__CLASS__, 'defaultProductSelectionDraftBuilderFunction'],
+            $assertFunction,
+            $createFunction,
+            $deleteFunction,
+            $draftFunction
+        );
+    }
+}

--- a/tests/integration/ProductSelection/ProductSelectionQueryRequestTest.php
+++ b/tests/integration/ProductSelection/ProductSelectionQueryRequestTest.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Commercetools\Core\IntegrationTests\ProductSelection;
+
+use Commercetools\Core\Builder\Request\RequestBuilder;
+use Commercetools\Core\IntegrationTests\ApiTestCase;
+use Commercetools\Core\Model\Common\LocalizedString;
+use Commercetools\Core\Model\ProductSelection\ProductSelection;
+use Commercetools\Core\Model\ProductSelection\ProductSelectionDraft;
+use Commercetools\Core\Response\PagedQueryResponse;
+
+class ProductSelectionQueryRequestTest extends ApiTestCase
+{
+
+    //TODO tests for  product and store actions
+    public function testGetById()
+    {
+        $client = $this->getApiClient();
+
+        ProductSelectionFixture::withProductSelection(
+            $client,
+            function (ProductSelection $productSelection) use ($client) {
+                $request = RequestBuilder::of()->productSelections()->getById($productSelection->getId());
+                $response = $this->execute($client, $request);
+                $result = $request->mapFromResponse($response);
+
+                $this->assertInstanceOf(ProductSelection::class, $productSelection);
+                $this->assertSame($productSelection->getId(), $result->getId());
+            }
+        );
+    }
+
+    public function testGetByKey()
+    {
+        $client = $this->getApiClient();
+
+        ProductSelectionFixture::withDraftProductSelection(
+            $client,
+            function (ProductSelectionDraft $draft) {
+                return $draft->setKey('key-' . ProductSelectionFixture::uniqueProductSelectionString());
+            },
+            function (ProductSelection $productSelection) use ($client) {
+                $request = RequestBuilder::of()->productSelections()->getByKey($productSelection->getKey());
+                $response = $this->execute($client, $request);
+                $result = $request->mapFromResponse($response);
+
+                $this->assertInstanceOf(ProductSelection::class, $productSelection);
+                $this->assertSame($productSelection->getId(), $result->getId());
+                $this->assertSame($productSelection->getKey(), $result->getKey());
+            }
+        );
+    }
+
+    public function testOverpaging()
+    {
+        $client = $this->getApiClient();
+
+        ProductSelectionFixture::withDraftProductSelection(
+            $client,
+            function (ProductSelectionDraft $draft) {
+                return $draft->setName(LocalizedString::ofLangAndText('en', 'MyProductSelection'));
+            },
+            function (ProductSelection $productSelection) use ($client) {
+                $request = RequestBuilder::of()->productSelections()->query()->offset(10000);
+                $response = $this->execute($client, $request);
+                $pageQueryResponse = new PagedQueryResponse($response, $request);
+
+                $this->assertSame(10000, $pageQueryResponse->getOffset());
+                $this->assertSame(0, $pageQueryResponse->getCount());
+                $this->assertCount(0, $pageQueryResponse->toObject());
+            }
+        );
+    }
+}

--- a/tests/integration/ProductSelection/ProductSelectionUpdateRequestTest.php
+++ b/tests/integration/ProductSelection/ProductSelectionUpdateRequestTest.php
@@ -1,0 +1,135 @@
+<?php
+
+namespace Commercetools\Core\IntegrationTests\ProductSelection;
+
+use Commercetools\Core\Builder\Request\RequestBuilder;
+use Commercetools\Core\IntegrationTests\ApiTestCase;
+use Commercetools\Core\IntegrationTests\Product\ProductFixture;
+use Commercetools\Core\Model\Common\LocalizedString;
+use Commercetools\Core\Model\Product\Product;
+use Commercetools\Core\Model\Product\ProductReference;
+use Commercetools\Core\Model\ProductSelection\ProductSelection;
+use Commercetools\Core\Request\ProductSelections\Command\ProductSelectionAddProductAction;
+use Commercetools\Core\Request\ProductSelections\Command\ProductSelectionChangeNameAction;
+use Commercetools\Core\Request\ProductSelections\Command\ProductSelectionRemoveProductAction;
+use Commercetools\Core\Request\ProductSelections\Command\ProductSelectionSetKeyAction;
+
+class ProductSelectionUpdateRequestTest extends ApiTestCase
+{
+    public function testChangeName()
+    {
+        $client = $this->getApiClient();
+
+        ProductSelectionFixture::withUpdateableProductSelection(
+            $client,
+            function (ProductSelection $product) use ($client) {
+                $name = 'new name-' . ProductSelectionFixture::uniqueProductSelectionString();
+
+                $request = RequestBuilder::of()->productSelections()->update($product)
+                    ->addAction(
+                        ProductSelectionChangeNameAction::ofName(
+                            LocalizedString::ofLangAndText('en', $name)
+                        )
+                    );
+                $response = $this->execute($client, $request);
+                $result = $request->mapFromResponse($response);
+
+                $this->assertInstanceOf(ProductSelection::class, $result);
+                $this->assertNotSame($product->getName(), $result->getName()->en);
+                $this->assertSame($name, $result->getName()->en);
+
+                return $result;
+            }
+        );
+    }
+
+    public function testSetKey()
+    {
+        $client = $this->getApiClient();
+
+        ProductSelectionFixture::withUpdateableProductSelection(
+            $client,
+            function (ProductSelection $product) use ($client) {
+                $key = 'new-key-' . ProductSelectionFixture::uniqueProductSelectionString();
+
+                $request = RequestBuilder::of()->productSelections()->update($product)
+                    ->addAction(
+                        ProductSelectionSetKeyAction::ofKey($key)
+                    );
+                $response = $this->execute($client, $request);
+                $result = $request->mapFromResponse($response);
+
+                $this->assertInstanceOf(ProductSelection::class, $result);
+                $this->assertNotSame($product->getKey(), $result->getKey());
+                $this->assertSame($key, $result->getKey());
+
+                return $result;
+            }
+        );
+    }
+
+    public function testAddProduct()
+    {
+        $client = $this->getApiClient();
+
+        ProductFixture::withProduct(
+            $client,
+            function (Product $product) use ($client) {
+                ProductSelectionFixture::withUpdateableProductSelection(
+                    $client,
+                    function (ProductSelection $productSelection) use ($client, $product) {
+                        $productReference = ProductReference::ofId($product->getId());
+
+                        $request = RequestBuilder::of()->productSelections()->update($productSelection)
+                            ->addAction(
+                                ProductSelectionAddProductAction::ofProduct($productReference)
+                            );
+                        $response = $this->execute($client, $request);
+                        $result = $request->mapFromResponse($response);
+
+                        $this->assertInstanceOf(ProductSelection::class, $result);
+
+                        return $result;
+                    }
+                );
+            }
+        );
+    }
+
+    public function testRemoveProduct()
+    {
+        $client = $this->getApiClient();
+
+        ProductFixture::withProduct(
+            $client,
+            function (Product $product) use ($client) {
+                ProductSelectionFixture::withUpdateableProductSelection(
+                    $client,
+                    function (ProductSelection $productSelection) use ($client, $product) {
+                        $productReference = ProductReference::ofId($product->getId());
+
+                        $request = RequestBuilder::of()->productSelections()->update($productSelection)
+                            ->addAction(
+                                ProductSelectionAddProductAction::ofProduct($productReference)
+                            );
+                        $response = $this->execute($client, $request);
+                        $productSelectionResult = $request->mapFromResponse($response);
+
+                        $this->assertInstanceOf(ProductSelection::class, $productSelectionResult);
+
+                        $request = RequestBuilder::of()->productSelections()->update($productSelectionResult)
+                            ->addAction(
+                                ProductSelectionRemoveProductAction::ofProduct($productReference)
+                            );
+                        $response = $this->execute($client, $request);
+                        $result = $request->mapFromResponse($response);
+
+                        $this->assertInstanceOf(ProductSelection::class, $result);
+
+                        return $result;
+                    }
+                );
+            }
+        );
+    }
+}

--- a/tests/unit/Request/GenericUpdateRequestTest.php
+++ b/tests/unit/Request/GenericUpdateRequestTest.php
@@ -19,6 +19,7 @@ use Commercetools\Core\Model\OrderEdit\OrderEdit;
 use Commercetools\Core\Model\Payment\Payment;
 use Commercetools\Core\Model\Product\Product;
 use Commercetools\Core\Model\ProductDiscount\ProductDiscount;
+use Commercetools\Core\Model\ProductSelection\ProductSelection;
 use Commercetools\Core\Model\ProductType\ProductType;
 use Commercetools\Core\Model\Review\Review;
 use Commercetools\Core\Model\ShippingMethod\ShippingMethod;
@@ -42,6 +43,7 @@ use Commercetools\Core\Request\Orders\OrderUpdateRequest;
 use Commercetools\Core\Request\Payments\PaymentUpdateRequest;
 use Commercetools\Core\Request\ProductDiscounts\ProductDiscountUpdateRequest;
 use Commercetools\Core\Request\Products\ProductUpdateRequest;
+use Commercetools\Core\Request\ProductSelections\ProductSelectionUpdateRequest;
 use Commercetools\Core\Request\ProductTypes\ProductTypeUpdateRequest;
 use Commercetools\Core\Request\Reviews\ReviewUpdateRequest;
 use Commercetools\Core\Request\ShippingMethods\ShippingMethodUpdateRequest;
@@ -166,6 +168,10 @@ class GenericUpdateRequestTest extends RequestTestCase
                 StoreUpdateRequest::class,
                 Store::class,
             ],
+            ProductSelectionUpdateRequest::class => [
+                ProductSelectionUpdateRequest::class,
+                ProductSelection::class
+            ]
         ];
     }
 

--- a/tests/unit/Request/ProductSelection/ProductSelectionByIdProductsGetRequestTest.php
+++ b/tests/unit/Request/ProductSelection/ProductSelectionByIdProductsGetRequestTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Commercetools\Core\Request\ProductSelection;
+
+use Commercetools\Core\Model\ProductSelection\ProductSelection;
+use Commercetools\Core\Request\ProductSelections\ProductSelectionByIdProductsGetRequest;
+use Commercetools\Core\RequestTestCase;
+use Commercetools\Core\Response\ResourceResponse;
+
+class ProductSelectionByIdProductsGetRequestTest extends RequestTestCase
+{
+    const PRODUCT_SELECTION_BY_ID_PRODUCTS_GET_REQUEST = ProductSelectionByIdProductsGetRequest::class;
+
+    public function testMapResult()
+    {
+        $result = $this->mapResult(ProductSelectionByIdProductsGetRequest::ofId('id'));
+        $this->assertInstanceOf(ProductSelection::class, $result);
+    }
+
+    public function testMapEmptyResult()
+    {
+        $result = $this->mapEmptyResult(ProductSelectionByIdProductsGetRequest::ofId('id'));
+        $this->assertNull($result);
+    }
+
+    public function testHttpRequestPath()
+    {
+        $request = ProductSelectionByIdProductsGetRequest::ofId('id');
+        $httpRequest = $request->httpRequest();
+
+        $this->assertSame('product-selections/id/products', (string)$httpRequest->getUri());
+    }
+
+    public function testBuildResponse()
+    {
+        $mockBuilder = $this->getMockBuilder('\GuzzleHttp\Psr7\Response');
+        $mockBuilder->disableOriginalConstructor();
+        $guzzleResponse = $mockBuilder->getMock();
+
+        $request = ProductSelectionByIdProductsGetRequest::ofId('id');
+        $response = $request->buildResponse($guzzleResponse);
+
+        $this->assertInstanceOf(ResourceResponse::class, $response);
+    }
+}

--- a/tests/unit/Request/ProductSelection/ProductSelectionByKeyProductsGetRequestTest.php
+++ b/tests/unit/Request/ProductSelection/ProductSelectionByKeyProductsGetRequestTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Commercetools\Core\Request\ProductSelection;
+
+use Commercetools\Core\Model\ProductSelection\ProductSelection;
+use Commercetools\Core\Request\ProductSelections\ProductSelectionByKeyProductsGetRequest;
+use Commercetools\Core\RequestTestCase;
+use Commercetools\Core\Response\ResourceResponse;
+
+class ProductSelectionByKeyProductsGetRequestTest extends RequestTestCase
+{
+    const PRODUCT_SELECTION_BY_KEY_PRODUCTS_GET_REQUEST = ProductSelectionByKeyProductsGetRequest::class;
+
+    public function testMapResult()
+    {
+        $result = $this->mapResult(ProductSelectionByKeyProductsGetRequest::ofKey('key'));
+        $this->assertInstanceOf(ProductSelection::class, $result);
+    }
+
+    public function testMapEmptyResult()
+    {
+        $result = $this->mapEmptyResult(ProductSelectionByKeyProductsGetRequest::ofKey('key'));
+        $this->assertNull($result);
+    }
+
+    public function testHttpRequestPath()
+    {
+        $request = ProductSelectionByKeyProductsGetRequest::ofKey('key');
+        $httpRequest = $request->httpRequest();
+
+        $this->assertSame('product-selections/key=key/products', (string)$httpRequest->getUri());
+    }
+
+    public function testBuildResponse()
+    {
+        $mockBuilder = $this->getMockBuilder('\GuzzleHttp\Psr7\Response');
+        $mockBuilder->disableOriginalConstructor();
+        $guzzleResponse = $mockBuilder->getMock();
+
+        $request = ProductSelectionByKeyProductsGetRequest::ofKey('key');
+        $response = $request->buildResponse($guzzleResponse);
+
+        $this->assertInstanceOf(ResourceResponse::class, $response);
+    }
+}

--- a/tests/unit/Request/ProductSelection/ProductSelectionCreateRequestTest.php
+++ b/tests/unit/Request/ProductSelection/ProductSelectionCreateRequestTest.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Commercetools\Core\Request\ProductSelection;
+
+use Commercetools\Core\Model\Common\LocalizedString;
+use Commercetools\Core\Model\ProductSelection\ProductSelection;
+use Commercetools\Core\Model\ProductSelection\ProductSelectionDraft;
+use Commercetools\Core\Request\ProductSelections\ProductSelectionCreateRequest;
+use Commercetools\Core\RequestTestCase;
+
+class ProductSelectionCreateRequestTest extends RequestTestCase
+{
+    const PRODUCT_SELECTION_CREATE_REQUEST = ProductSelectionCreateRequest::class;
+
+    public function getProductSelection()
+    {
+        return ProductSelectionDraft::ofName(
+            LocalizedString::fromArray(['en' => 'productSelectionName'])
+        );
+    }
+
+    public function testMapResult()
+    {
+        $result = $this->mapResult(ProductSelectionCreateRequest::ofDraft($this->getProductSelection()));
+        $this->assertInstanceOf(ProductSelection::class, $result);
+    }
+
+    public function testMapEmptyResult()
+    {
+        $result = $this->mapEmptyResult(ProductSelectionCreateRequest::ofDraft($this->getProductSelection()));
+        $this->assertNull($result);
+    }
+}

--- a/tests/unit/Request/ProductSelection/ProductSelectionQueryRequestTest.php
+++ b/tests/unit/Request/ProductSelection/ProductSelectionQueryRequestTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Commercetools\Core\Request\ProductSelection;
+
+use Commercetools\Core\Model\ProductSelection\ProductSelectionCollection;
+use Commercetools\Core\Request\ProductSelections\ProductSelectionByIdProductsGetRequest;
+use Commercetools\Core\Request\ProductSelections\ProductSelectionQueryRequest;
+use Commercetools\Core\RequestTestCase;
+use Commercetools\Core\Response\PagedQueryResponse;
+
+class ProductSelectionQueryRequestTest extends RequestTestCase
+{
+    const PRODUCT_SELECTION_QUERY_REQUEST = ProductSelectionQueryRequest::class;
+
+    public function testMapResult()
+    {
+        $data = [
+            'results' => [
+                ['id' => 'value'],
+                ['id' => 'value'],
+                ['id' => 'value'],
+            ]
+        ];
+        $result = $this->mapQueryResult(ProductSelectionQueryRequest::of(), [], $data);
+        $this->assertInstanceOf(ProductSelectionCollection::class, $result);
+        $this->assertCount(3, $result);
+    }
+
+    public function testMapEmptyResult()
+    {
+        $result = $this->mapEmptyResult(ProductSelectionQueryRequest::of());
+        $this->assertInstanceOf(ProductSelectionCollection::class, $result);
+    }
+
+    public function testBuildResponse()
+    {
+        $mockBuilder = $this->getMockBuilder('\GuzzleHttp\Psr7\Response');
+        $mockBuilder->disableOriginalConstructor();
+        $guzzleResponse = $mockBuilder->getMock();
+
+        $request = ProductSelectionQueryRequest::of();
+        $response = $request->buildResponse($guzzleResponse);
+
+        $this->assertInstanceOf(PagedQueryResponse::class, $response);
+    }
+}


### PR DESCRIPTION
1. code and add tests that cover the created code. Your code should be warning-free.
   * [ ] tests existing
1. stick to PSR-2 and and don't reformat existing code.
   * [ ] code style check successful


Still missing:
- [ ] in-store/product-selection-assignments
- [ ] products/{id}/product-selections 
- [ ] products/key=key/product-selections
- [ ] StoreAddProductSelectionAction, StoreChangeProductSelectionAction, StoreRemoveProductSelectionAction, StoreSetProductSelectionsAction
- [ ] ProductSelectionCreatedMessage, ProductSelectionDeletedMessage, ProductSelectionProductAddedMessage, ProductSelectionProductRemovedMessage, StoreProductSelectionsChangedMessage
- [ ] to modify StoreCreateMessage 
