### PR TITLE
chore(docs): update naming to match new branding initiative

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -476,7 +476,7 @@
   - DoctrineCacheAdapter
   - NullCacheAdapter
   - PhpRedisCacheAdapter
-  
+
   Use an appropiate PSR-6 or PRS-16 cache adapter as a replacement. The SDK uses the [cache\apcu-adapter](https://packagist.org/packages/cache/apcu-adapter) as default or if available the [cache\filesystem-adapter](https://packagist.org/packages/cache/filesystem-adapter)
 * Deprecations have been removed
   - FileRequest
@@ -490,9 +490,8 @@
 
 ### DEPRECATION NOTE
 
-The class ```Commercetools\Commons\Helper\PriceFinder``` has been deprecated. Please use the 
-[price selection](http://docs.commercetools.com/http-api-projects-products.html#price-selection) functionality of
-the platform. E.g. ```ProductProjectionSearchRequest::of()->currency('EUR')->country('DE')```
+The class ```Commercetools\Commons\Helper\PriceFinder``` has been deprecated. Please use the
+[price selection](http://docs.commercetools.com/http-api-projects-products.html#price-selection) functionality of Composable Commerce. E.g. ```ProductProjectionSearchRequest::of()->currency('EUR')->country('DE')```
 
 
 <a name="2.0.0-RC1"></a>
@@ -543,7 +542,7 @@ the platform. E.g. ```ProductProjectionSearchRequest::of()->currency('EUR')->cou
   ```
   $request = ProductProjectionSearchRequest::of()->markMatchingVariants(true);
   ```
-  
+
 * PHP minimum version is now 5.6
 * Token caching is now using [PSR-6](https://packagist.org/providers/psr/cache-implementation) or [PSR-16](https://packagist.org/providers/psr/simple-cache-implementation) cache adapters only.
   Removed classes:
@@ -554,7 +553,7 @@ the platform. E.g. ```ProductProjectionSearchRequest::of()->currency('EUR')->cou
   - DoctrineCacheAdapter
   - NullCacheAdapter
   - PhpRedisCacheAdapter
-  
+
   Use an appropiate PSR-6 or PRS-16 cache adapter as a replacement. The SDK uses the [cache\apcu-adapter](https://packagist.org/packages/cache/apcu-adapter) as default or if available the [cache\filesystem-adapter](https://packagist.org/packages/cache/filesystem-adapter)
 * Deprecations have been removed
   - FileRequest
@@ -860,53 +859,53 @@ There had been no changes
 * Product: renamed the ProductSetSKUAction to ProductSetSKUNotStageableAction
 
   Before:
-  
+
   ```
   ProductSetSKUAction::ofVariantId()
   ```
 
   After:
-  
+
   ```
   ProductSetSKUNotStageableAction::ofVariantId() // old behavior action
   ProductSetSkuAction::ofVariantId() // stageable action
   ```
 * Product: fix type of price collections
-  
+
   Before:
-  
+
   ```
   ProductAddVariantAction::of()->setPrices(PriceCollection::of()->add(Price::of()))
   ```
 
   After:
-  
+
   ```
   ProductAddVariantAction::of()->setPrices(PriceDraftCollection::of()->add(PriceDraft::of()))
   ```
 * Customer: adjust customer email verification request to API changes
 
   Before:
-  
+
   ```
   CustomerEmailConfirmRequest::ofIdVersionAndToken($id, $version, $token)
   ```
 
   After:
-  
+
   ```
   CustomerEmailConfirmRequest::ofToken($token)
   ```
 * Customer: adjust customer password change request to API changes
 
   Before:
-  
+
   ```
   CustomerPasswordResetRequest::ofIdVersionTokenAndPassword($id, $version, $token, $newPassword)
   ```
 
   After:
-  
+
   ```
   CustomerPasswordResetRequest::ofTokenAndPassword($token, $newPassword)
   ```
@@ -960,9 +959,9 @@ Facet, Filter, FilterRange and FilterRangeCollection in namespace Commercetools\
 
 ### BREAKING CHANGES
 * Changed named constructors for type update actions
-  
+
   Before:
-  
+
   ```
   TypeAddLocalizedEnumValueAction::ofEnum(...)
   TypeAddEnumValueAction::ofEnum(...)
@@ -970,9 +969,9 @@ Facet, Filter, FilterRange and FilterRangeCollection in namespace Commercetools\
   TypeChangeLocalizedEnumValueOrderAction::ofEnums(...)
   TypeChangeLabelAction::ofLabel(...)
   ```
-  
+
   After:
-  
+
   ```
   TypeAddLocalizedEnumValueAction::ofNameAndEnum(...)
   TypeAddEnumValueAction::ofNameAndEnum(...)

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ We recommend to use our [PHP SDK V2](https://docs.commercetools.com/sdk/php-sdk#
 
 [![Build Status](https://img.shields.io/travis/com/commercetools/commercetools-php-sdk/master.svg?style=flat-square)](https://travis-ci.com/commercetools/commercetools-php-sdk) [![Scrutinizer](https://img.shields.io/scrutinizer/g/commercetools/commercetools-php-sdk.svg?style=flat-square)](https://scrutinizer-ci.com/g/commercetools/commercetools-php-sdk/) [![Scrutinizer](https://img.shields.io/scrutinizer/coverage/g/commercetools/commercetools-php-sdk.svg?style=flat-square)](https://scrutinizer-ci.com/g/commercetools/commercetools-php-sdk/) [![Packagist](https://img.shields.io/packagist/v/commercetools/php-sdk.svg?style=flat-square)](https://packagist.org/packages/commercetools/php-sdk) [![Packagist](https://img.shields.io/packagist/dm/commercetools/php-sdk.svg?style=flat-square)](https://packagist.org/packages/commercetools/php-sdk)
 
-The PHP SDK allows developers to build applications on Composable Commerce (technically speaking against our REST API) using PHP native interfaces, models and helpers instead of manually using the HTTP and JSON API.
+The PHP SDK allows developers to integrate with Composable Commerce APIs using PHP native interfaces, models and helpers instead of manually using the HTTP and JSON API.
 
 You gain lots of IDE Auto-Completion, type checks on a literal API, Warnings, Object Mapping, i18n support etc.. The Client manages the OAuth2 security tokens, provides caches and interfaces for concurrent and asynchronous API calls.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# <img src="build/theme/resources/CT_cube_200px.png" width="40" align="center"></img> commercetools PHP SDK
+# <img src="build/theme/resources/CT_cube_200px.png" width="40" align="center"></img> Composable Commerce PHP SDK
 
-:warning: **This commercetools PHP SDK is in its Active Support mode currently, and is planned to be deprecated, please note the following dates.
+:warning: **This Composable Commerce PHP SDK is in its Active Support mode currently, and is planned to be deprecated, please note the following dates.
 
 | Active Support        | Maintenance Support   | End of Life           |
 | --------------------- | --------------------- | --------------------- |
@@ -10,7 +10,7 @@ We recommend to use our [PHP SDK V2](https://docs.commercetools.com/sdk/php-sdk#
 
 [![Build Status](https://img.shields.io/travis/com/commercetools/commercetools-php-sdk/master.svg?style=flat-square)](https://travis-ci.com/commercetools/commercetools-php-sdk) [![Scrutinizer](https://img.shields.io/scrutinizer/g/commercetools/commercetools-php-sdk.svg?style=flat-square)](https://scrutinizer-ci.com/g/commercetools/commercetools-php-sdk/) [![Scrutinizer](https://img.shields.io/scrutinizer/coverage/g/commercetools/commercetools-php-sdk.svg?style=flat-square)](https://scrutinizer-ci.com/g/commercetools/commercetools-php-sdk/) [![Packagist](https://img.shields.io/packagist/v/commercetools/php-sdk.svg?style=flat-square)](https://packagist.org/packages/commercetools/php-sdk) [![Packagist](https://img.shields.io/packagist/dm/commercetools/php-sdk.svg?style=flat-square)](https://packagist.org/packages/commercetools/php-sdk)
 
-The PHP SDK allows developers to build applications on the commercetools platform (technically speaking against our REST API) using PHP native interfaces, models and helpers instead of manually using the HTTP and JSON API.
+The PHP SDK allows developers to build applications on Composable Commerce (technically speaking against our REST API) using PHP native interfaces, models and helpers instead of manually using the HTTP and JSON API.
 
 You gain lots of IDE Auto-Completion, type checks on a literal API, Warnings, Object Mapping, i18n support etc.. The Client manages the OAuth2 security tokens, provides caches and interfaces for concurrent and asynchronous API calls.
 
@@ -70,7 +70,7 @@ Please read the [Changelog](CHANGELOG.md) before updating in any case.
 
 ### Getting started
 
-To get up and running, create a free test project ([EU located](https://mc.commercetools.com/login/new) or [US located](https://mc.commercetools.co/login/new)) on the commercetools platform. To generate your API credentials go to [EU Merchant Center](https://mc.commercetools.com/) or [US Merchant Center](https://mc.commercetools.co/) (Menu "Settings"->"Developer Settings"->"API Clients"->"Create New Api Client").
+To get up and running, create a free test project ([EU located](https://mc.commercetools.com/login/new) or [US located](https://mc.commercetools.co/login/new)) on Composable Commerce. To generate your API credentials go to [EU Merchant Center](https://mc.commercetools.com/) or [US Merchant Center](https://mc.commercetools.co/) (Menu "Settings"->"Developer Settings"->"API Clients"->"Create New Api Client").
 You need to select the template for the "Admin client".
 
 ```php
@@ -234,7 +234,7 @@ $client = ClientFactory::of()->createClient($config, $logger, $cache);
 
 #### Middlewares
 
-Adding middlewares to the clients for platform as well for the authentication can be done using the config
+Adding middlewares to the clients for Composable Commerce as well for the authentication can be done using the config
 by setting client options.
 
 For using a custom HandlerStack
@@ -344,7 +344,7 @@ $response = $client->execute($request);
 $project = $request->mapFromResponse($response);
 var_dump($project->toArray());
 ```
- 
+
 ## Improve & Contribute to the SDK project
 
 ### Mac OS X preparations:
@@ -419,7 +419,7 @@ Now you can enable at Preferences > Editor > Inspections > PHP the "PHP code sni
 
 ### Running integration tests
 
-For running the integration tests you need an empty commercetools project and have to create an API client using the commercetools Merchant Center with the scopes:
+For running the integration tests you need an empty Project and have to create an API client using the commercetools Merchant Center with the scopes:
 ```
 manage_project
 view_orders

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Please read the [Changelog](CHANGELOG.md) before updating in any case.
 
 ### Getting started
 
-To get up and running, create a free test project ([EU located](https://mc.commercetools.com/login/new) or [US located](https://mc.commercetools.co/login/new)) on Composable Commerce. To generate your API credentials go to [EU Merchant Center](https://mc.commercetools.com/) or [US Merchant Center](https://mc.commercetools.co/) (Menu "Settings"->"Developer Settings"->"API Clients"->"Create New Api Client").
+To get up and running, create a free test [Project](https://mc.commercetools.com/login/new) on Composable Commerce. You can create your first API Client in [The Merchant Center](https://mc.commercetools.com/) (Menu "Settings"->"Developer settings"->"Create new API client").
 You need to select the template for the "Admin client".
 
 ```php

--- a/build/theme/@layout.latte
+++ b/build/theme/@layout.latte
@@ -27,7 +27,7 @@
 	<nav id="navigation" class="navbar navbar-default navbar-fixed-top">
 		<div class="container-fluid">
 			<div class="navbar-header">
-				<a href="index.html" class="navbar-brand"><img src="{='resources/ct-logo.svg'|staticFile}" id="navbar-logo" alt="commercetools platform PHP SDK">{if $config->title}{$config->title} {getenv('SDK_VERSION')}{else}Overview{/if}</a>
+				<a href="index.html" class="navbar-brand"><img src="{='resources/ct-logo.svg'|staticFile}" id="navbar-logo" alt="Composable Commerce PHP SDK">{if $config->title}{$config->title} {getenv('SDK_VERSION')}{else}Overview{/if}</a>
 			</div>
 			<div class="collapse navbar-collapse">
 

--- a/docroot/factory.php
+++ b/docroot/factory.php
@@ -57,7 +57,7 @@ $products = $request->mapFromResponse($response);
 ?>
 <html>
 <head>
-    <title>Commercetools PHP SDK example</title>
+    <title>Composable Commerce PHP SDK example</title>
 </head>
 <body>
     <form method="POST" action=".">

--- a/docroot/index.php
+++ b/docroot/index.php
@@ -55,7 +55,7 @@ $products = $request->mapFromResponse($response);
 ?>
 <html>
 <head>
-    <title>Commercetools PHP SDK example</title>
+    <title>Composable Commerce PHP SDK example</title>
 </head>
 <body>
     <form method="POST" action=".">

--- a/docroot/myapp.yml.dist
+++ b/docroot/myapp.yml.dist
@@ -1,4 +1,4 @@
 parameters:
-  client_id: Your Commercetools client ID
-  client_secret: Your Commercetools client secret
-  project: Your Commercetools project key
+  client_id: Your Composable Commerce client ID
+  client_secret: Your Composable Commerce client secret
+  project: Your Composable Commerce project key

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "commercetools-php-sdk-changelog",
   "version": "2.19.0",
-  "description": "commercetools PHP SDK changelog generator package description",
+  "description": "Composable Commerce PHP SDK changelog generator package description",
   "homepage": "https://github.com/commercetools/commercetools-php-sdk",
   "bugs": "https://github.com/commercetools/commercetools-php-sdk/issues",
   "license": "MIT",

--- a/src/Commons/Helper/PriceFinder.php
+++ b/src/Commons/Helper/PriceFinder.php
@@ -11,7 +11,7 @@ use Commercetools\Core\Model\Common\PriceCollection;
 use Commercetools\Core\Model\CustomerGroup\CustomerGroupReference;
 
 /**
- * @deprecated Please use the price selection functionality of the platform
+ * @deprecated Please use the price selection functionality of Composable Commerce
  * @link http://docs.commercetools.com/http-api-projects-products.html#price-selection
  */
 class PriceFinder

--- a/src/Core/Client.php
+++ b/src/Core/Client.php
@@ -28,7 +28,7 @@ use Commercetools\Core\Client\OAuth\Manager;
 use function GuzzleHttp\Psr7\stream_for;
 
 /**
- * The client for communicating with the commercetools platform
+ * The client for communicating with Composable Commerce
  *
  * @description
  * ## Instantiation

--- a/src/Core/Client/ClientFactory.php
+++ b/src/Core/Client/ClientFactory.php
@@ -32,10 +32,10 @@ use Psr\Log\LogLevel;
 use Psr\SimpleCache\CacheInterface;
 
 /**
- * The factory to create a Client for communicating with the commercetools platform
+ * The factory to create a Client for communicating with Composable Commerce
  *
  * @description
- * This factory will create a Guzzle HTTP Client preconfigured for talking to the commercetools platform
+ * This factory will create a Guzzle HTTP Client preconfigured for talking to Composable Commerce
  *
  * ## Instantiation
  *
@@ -137,7 +137,7 @@ use Psr\SimpleCache\CacheInterface;
  *
  * ## Middlewares
  *
- * Adding middlewares to the clients for platform as well for the authentication can be done using the config
+ * Adding middlewares to the clients for Composable Commerce as well for the authentication can be done using the config
  * by setting client options.
  *
  * ### Using a HandlerStack

--- a/src/Core/Error/ConcurrentModificationException.php
+++ b/src/Core/Error/ConcurrentModificationException.php
@@ -9,8 +9,8 @@ namespace Commercetools\Core\Error;
  * Exeption for response with status code 409
  * @package Commercetools\Core\Error
  * @description
- * When trying to update a resource with a version which differs from the version stored at the commercetools
- * platform the API will respond with status code 409.
+ * When trying to update a resource with a version which differs from the version stored on Composable Commerce,
+ * the API will respond with status code 409.
  */
 class ConcurrentModificationException extends ClientErrorException
 {

--- a/src/Core/Error/ServiceUnavailableException.php
+++ b/src/Core/Error/ServiceUnavailableException.php
@@ -9,7 +9,7 @@ namespace Commercetools\Core\Error;
  * Exception for response with status code 503
  * @package Commercetools\Core\Error
  * @description
- * The commercetools platform is currently not available
+ * Composable Commerce is currently not available
  */
 class ServiceUnavailableException extends ServerErrorException
 {

--- a/src/Core/Request/Orders/Command/OrderAddDeliveryAction.php
+++ b/src/Core/Request/Orders/Command/OrderAddDeliveryAction.php
@@ -62,7 +62,7 @@ class OrderAddDeliveryAction extends AbstractAction
     }
 
     /**
-     * @deprecated not supported by platform - will be removed in 3.0
+     * @deprecated not supported by Composable Commerce - will be removed in 3.0
      * @return null
      */
     public function getMeasurements()
@@ -71,7 +71,7 @@ class OrderAddDeliveryAction extends AbstractAction
     }
 
     /**
-     * @deprecated not supported by platform - will be removed in 3.0
+     * @deprecated not supported by Composable Commerce - will be removed in 3.0
      * @return OrderAddDeliveryAction
      */
     public function setMeasurements()
@@ -80,7 +80,7 @@ class OrderAddDeliveryAction extends AbstractAction
     }
 
     /**
-     * @deprecated not supported by platform - will be removed in 3.0
+     * @deprecated not supported by Composable Commerce - will be removed in 3.0
      * @return null
      */
     public function getTrackingData()
@@ -89,7 +89,7 @@ class OrderAddDeliveryAction extends AbstractAction
     }
 
     /**
-     * @deprecated not supported by platform - will be removed in 3.0
+     * @deprecated not supported by Composable Commerce - will be removed in 3.0
      * @return OrderAddDeliveryAction
      */
     public function setTrackingData()

--- a/src/Core/Request/Products/Command/ProductSetTaxCategoryAction.php
+++ b/src/Core/Request/Products/Command/ProductSetTaxCategoryAction.php
@@ -38,7 +38,7 @@ class ProductSetTaxCategoryAction extends AbstractAction
     }
 
     /**
-     * @deprecated not supported by platform - will be removed in 3.0
+     * @deprecated not supported by Composable Commerce - will be removed in 3.0
      * @return null
      */
     public function getStaged()
@@ -47,7 +47,7 @@ class ProductSetTaxCategoryAction extends AbstractAction
     }
 
     /**
-     * @deprecated not supported by platform - will be removed in 3.0
+     * @deprecated not supported by Composable Commerce - will be removed in 3.0
      * @return ProductSetTaxCategoryAction
      */
     public function setStaged()

--- a/tests/myapp.yml.dist
+++ b/tests/myapp.yml.dist
@@ -1,7 +1,7 @@
 parameters:
-  client_id: Your Commercetools client ID
-  client_secret: Your Commercetools client secret
-  project: Your Commercetools project key
+  client_id: Your Composable Commerce client ID
+  client_secret: Your Composable Commerce client secret
+  project: Your Project key
   oauth_url: https://auth.europe-west1.gcp.commercetools.com
   api_url: https://api.europe-west1.gcp.commercetools.com
   enableCorrelationId: 1

--- a/tests/myapp.yml.dist
+++ b/tests/myapp.yml.dist
@@ -1,7 +1,7 @@
 parameters:
   client_id: Your Composable Commerce client ID
   client_secret: Your Composable Commerce client secret
-  project: Your Project key
+  project: Your Composable Commerce Project key
   oauth_url: https://auth.europe-west1.gcp.commercetools.com
   api_url: https://api.europe-west1.gcp.commercetools.com
   enableCorrelationId: 1


### PR DESCRIPTION
# Description
This PR follows the rebranding initiative by the Marketing and Docs team to change commercetools to Composable Commerce.

https://github.com/commercetools/clients-team-internal/issues/87

NB: This PR does not update the tests, as this is out of scope.